### PR TITLE
Fixed bug for long and no-op not running

### DIFF
--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -50,7 +50,7 @@ class BaseDataOperation(ABC):
         """
 
     @abstractmethod
-    def operate(self):
+    def operate(self, cache_key, input_files):
         """ The method that performs the data operation.
             It should periodically update the percent completion during its operation.
             It should set the output and status into the cache when done.

--- a/datalab/datalab_session/data_operations/long.py
+++ b/datalab/datalab_session/data_operations/long.py
@@ -36,7 +36,7 @@ class LongOperation(BaseDataOperation):
             }            
         }
     
-    def operate(self):
+    def operate(self, cache_key, input_files):
         num_files = len(self.input_data.get('input_files', []))
         per_image_timeout = ceil(float(self.input_data.get('duration', 60.0)) / num_files)
         for i, file in enumerate(self.input_data.get('input_files', [])):

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -38,7 +38,7 @@ The output is a median image for the n input images. This operation is commonly 
             }
         }
     
-    def operate(self, input_files, cache_key):
+    def operate(self, cache_key, input_files):
 
         log.info(f'Executing median operation on {len(input_files)} files')
 

--- a/datalab/datalab_session/data_operations/noop.py
+++ b/datalab/datalab_session/data_operations/noop.py
@@ -40,7 +40,7 @@ class NoOperation(BaseDataOperation):
             }            
         }
     
-    def operate(self):
+    def operate(self, cache_key, input_files):
         print("No-op triggered!")
         output = {
             'output_files': self.input_data.get('input_files', [])

--- a/datalab/datalab_session/tasks.py
+++ b/datalab/datalab_session/tasks.py
@@ -19,4 +19,4 @@ def execute_data_operation(data_operation_name: str, input_data: dict):
         operation = operation_class(input_data)
         cache_key = operation.generate_cache_key()
 
-        operation.operate(input_data.get('input_files', []), cache_key)
+        operation.operate(cache_key, input_data.get('input_files', []))


### PR DESCRIPTION
Fixing mistake where Args for the two previous operations long and no-op weren't updated to accept cache_key and input_files which was causing them to error out when executed. 