### PR TITLE
Added pytest-django and some unit tests for util.py and data_operation subclass median

### DIFF
--- a/datalab/datalab_session/tests/test_data_operation.py
+++ b/datalab/datalab_session/tests/test_data_operation.py
@@ -46,3 +46,5 @@ class TestMedianOperation:
     }
     assert normalized_data == expected_data
 
+  def test_name_is_median(self):
+    assert Median.name() == 'Median'

--- a/datalab/datalab_session/tests/test_data_operation.py
+++ b/datalab/datalab_session/tests/test_data_operation.py
@@ -1,0 +1,48 @@
+from datalab.datalab_session.data_operations.median import Median
+
+class TestMedianOperation:
+  def test_generate_cache_key(self):
+    input_data = {'key1': 'value1', 'key2': 'value2'}
+    data_operation = Median(input_data)
+    cache_key = data_operation.generate_cache_key()
+    assert isinstance(cache_key, str)
+    assert len(cache_key) > 0
+
+  def test_normalize_input_data_with_none_input(self):
+    input_data = None
+    data_operation = Median(input_data)
+    normalized_data = data_operation._normalize_input_data(input_data)
+    assert normalized_data == {}
+
+  def test_normalize_input_data_with_empty_input(self):
+    input_data = {}
+    data_operation = Median(input_data)
+    normalized_data = data_operation._normalize_input_data(input_data)
+    assert normalized_data == {}
+
+  def test_normalize_input_data_with_file_inputs(self):
+    input_data = {
+      'file1': [{'basename': 'file1.txt'}, {'basename': 'file2.txt'}],
+      'file2': [{'basename': 'file3.txt'}, {'basename': 'file4.txt'}]
+    }
+    data_operation = Median(input_data)
+    normalized_data = data_operation._normalize_input_data(input_data)
+    expected_data = {
+      'file1': [{'basename': 'file1.txt'}, {'basename': 'file2.txt'}],
+      'file2': [{'basename': 'file3.txt'}, {'basename': 'file4.txt'}]
+    }
+    assert normalized_data == expected_data
+
+  def test_normalize_input_data_with_sorted_file_inputs(self):
+    input_data = {
+      'file1': [{'basename': 'file4.txt'}],
+      'file2': [{'basename': 'file1.txt'}]
+    }
+    data_operation = Median(input_data)
+    normalized_data = data_operation._normalize_input_data(input_data)
+    expected_data = {
+      'file2': [{'basename': 'file1.txt'}],
+      'file1': [{'basename': 'file4.txt'}]
+    }
+    assert normalized_data == expected_data
+

--- a/datalab/datalab_session/tests/test_utils.py
+++ b/datalab/datalab_session/tests/test_utils.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+from datalab.datalab_session.util import scale_points, stack_arrays
+
+def test_points_scale_points():
+    small_img_width = 200
+    small_img_height = 200
+    img_array = np.zeros((400, 400))
+    points = [(10, 20), (30, 40), (50, 60), (0, 0)]
+    expected_scaled_points = [(20, 40), (60, 80), (100, 120), (0, 0)]
+
+    scaled_points = scale_points(small_img_width, small_img_height, img_array, points)
+
+    assert len(scaled_points) == len(points)
+
+    for i in range(len(scaled_points)):
+      assert all([a == b for a, b in zip(scaled_points[i], expected_scaled_points[i])])
+
+def test_scale_points_aspect_check_fails():
+    small_img_width = 200
+    small_img_height = 200
+    img_array = np.zeros((400, 300))
+    points = [(10, 20), (30, 40), (50, 60), (0, 0)]
+
+    with pytest.raises(ValueError):
+        scale_points(small_img_width, small_img_height, img_array, points)
+
+def test_stack_arrays_equal_shape():
+  array_list = [np.zeros((10, 10)), np.ones((10, 10)), np.full((10, 10), 2)]
+  expected_shape = (10, 10, 3)
+  stacked = stack_arrays(array_list)
+  assert stacked.shape == expected_shape
+
+def test_stack_arrays_cropped_data():
+  array_list = [np.zeros((10, 10)), np.ones((15, 15)), np.full((12, 12), 2)]
+  expected_shape = (10, 10, 3)
+  stacked = stack_arrays(array_list)
+  assert stacked.shape == expected_shape
+
+def test_stack_arrays_empty_list():
+  array_list = []
+  with pytest.raises(ValueError):
+    stack_arrays(array_list)
+
+def test_stack_arrays_single_array():
+  array_list = [np.zeros((10, 10))]
+  expected_shape = (10, 10, 1)
+  stacked = stack_arrays(array_list)
+  assert stacked.shape == expected_shape

--- a/poetry.lock
+++ b/poetry.lock
@@ -452,7 +452,7 @@ files = [
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -606,7 +606,7 @@ djangorestframework = ">=3.14.0"
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -925,7 +925,7 @@ tifffile = ["tifffile"]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1267,7 +1267,7 @@ xmp = ["defusedxml"]
 name = "pluggy"
 version = "1.4.0"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
@@ -1420,7 +1420,7 @@ test = ["pytest", "pytest-doctestplus (>=0.7)"]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1438,6 +1438,25 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "pytest-django"
+version = "4.8.0"
+description = "A Django plugin for pytest."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-django-4.8.0.tar.gz", hash = "sha256:5d054fe011c56f3b10f978f41a8efb2e5adfc7e680ef36fb571ada1f24779d90"},
+    {file = "pytest_django-4.8.0-py3-none-any.whl", hash = "sha256:ca1ddd1e0e4c227cf9e3e40a6afc6d106b3e70868fd2ac5798a22501271cd0c7"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+testing = ["Django", "django-configurations (>=2.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -1738,7 +1757,7 @@ all = ["defusedxml", "fsspec", "imagecodecs (>=2023.8.12)", "lxml", "matplotlib"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1895,4 +1914,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "d5dd70dc9e6ebed41c1599313f21a78c0ee183302b897821929b8a975e4695c0"
+content-hash = "2b5507756a1821a03d05191e98e9f3305b5e95323025c1679aa20ee88d085e1c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ scikit-image = "^0.23.2"
 fsspec = "^2024.3.1"
 requests = "^2.31.0"
 aiohttp = "^3.9.5"
+pytest-django = "^4.8.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"


### PR DESCRIPTION
added tests for some of the basic functions of the operations median subclass and the util file. Just to get the ball rolling on this and encourage test writing for functions in the future.

If you think there are any other pieces that should have tests let me know and I can add them. This PR is just some of the functions I found but would like recommendations for more things to test and also how to test operations that interact with AWS without actually creating new files there. Or maybe those don't need to be tested since we'll see if they fail anyways.