### PR TITLE
Line Analysis Bug, Median Memmap Bug, Local Development Auth token changes

### DIFF
--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -1,13 +1,13 @@
 from skimage.measure import profile_line
 
-from datalab.datalab_session.util import scale_points
+from datalab.datalab_session.util import scale_flip_points
 
 # For creating an array of brightness along a user drawn line
 def line_profile(input: dict, sci_hdu: object):
   """
     Creates an array of luminosity values and the length of the line in arcseconds
   """
-  points = scale_points(input['width'], input['height'], sci_hdu.data, [(input["x1"], input["y1"]), (input["x2"], input["y2"])])
+  points = scale_flip_points(input['width'], input['height'], sci_hdu.data, [(input["x1"], input["y1"]), (input["x2"], input["y2"])])
   line_profile = profile_line(sci_hdu.data, points[0], points[1], mode="constant", cval=-1)
   arcsec = len(line_profile) * sci_hdu.header["PIXSCALE"]
 

--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -12,3 +12,9 @@ def line_profile(input: dict, sci_hdu: object):
   arcsec = len(line_profile) * sci_hdu.header["PIXSCALE"]
 
   return {"line_profile": line_profile, "arcsec": arcsec}
+
+def debug_point_on_sci_data(x, y, sci_hdu: object):
+  """
+    Debugging function to check a point (x,y) on the sci data has the same value as the point cross checked in DS9
+  """
+  print(f"data: {sci_hdu.data[y, x]}")

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -144,8 +144,9 @@ def scale_points(small_img_width: int, small_img_height: int, img_array: list, p
     Scale the coordinates from a smaller image to the full sized fits so we know the positions of the coords on the 2dnumpy array
     Returns the list of tuple points with coords scaled for the numpy array
   """
-
+  print(f"small_img_width: {small_img_width}, small_img_height: {small_img_height}")
   large_height, large_width = np.shape(img_array)
+  print(f"large_height: {large_height}, large_width: {large_width}")
 
   # If the aspect ratios don't match we can't be certain where the point was
   if small_img_width / small_img_height != large_width / large_height:
@@ -153,8 +154,11 @@ def scale_points(small_img_width: int, small_img_height: int, img_array: list, p
 
   width_scale = large_width / small_img_width
   height_scale = large_height / small_img_height
+  print(f"width_scale: {width_scale}, height_scale: {height_scale}")
 
   points_array = np.array(points)
+  print(f"points_array: {points_array}")
   scaled_points = np.int_(points_array * [width_scale, height_scale])
+  print(f"scaled_points: {scaled_points}")
 
   return scaled_points

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -88,7 +88,7 @@ def get_archive_from_basename(basename: str) -> dict:
   query_params = {'basename_exact': basename }
 
   headers = {
-    'Authorization': f'Token {settings.AUTH_TOKEN}'
+    'Authorization': f'Token {settings.ARCHIVE_API_TOKEN}'
   }
 
   response = requests.get(settings.ARCHIVE_API + '/frames/', params=query_params, headers=headers)

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -97,8 +97,7 @@ def get_archive_from_basename(basename: str) -> dict:
     image_data = response.json()
     results = image_data.get('results', None)
   except Exception as e:
-    log.error(f"failed to fetch {basename} from archive, Error: {e}")
-    raise FileNotFoundError
+    raise FileNotFoundError(f"Error fetching image data from archive: {e}")
 
   return results
 

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -87,13 +87,17 @@ def get_archive_from_basename(basename: str) -> dict:
   """
   query_params = {'basename_exact': basename }
 
-  response = requests.get(settings.ARCHIVE_API + '/frames/', params=query_params)
+  headers = {
+    'Authorization': f'Token {settings.AUTH_TOKEN}'
+  }
+
+  response = requests.get(settings.ARCHIVE_API + '/frames/', params=query_params, headers=headers)
 
   try:
     image_data = response.json()
     results = image_data.get('results', None)
-  except IndexError:
-    log.error(f"No image found with specified basename: {basename}")
+  except Exception as e:
+    log.error(f"failed to fetch {basename} from archive, Error: {e}")
     raise FileNotFoundError
 
   return results
@@ -111,11 +115,10 @@ def get_hdu(basename: str, extension: str = 'SCI') -> list[fits.HDUList]:
 
   try:
     fits_url = archive_record[0].get('url', 'No URL found')
-  except IndexError:
-    RuntimeWarning(f"No image found with specified basename: {basename}")
-
-  hdu = fits.open(fits_url)
-  return hdu[extension]
+    hdu = fits.open(fits_url)
+    return hdu[extension]
+  except Exception as e:
+    raise FileNotFoundError(f"No image found with specified basename: {basename} Error: {e}")
 
 def create_fits(key: str, image_arr: np.ndarray) -> fits.HDUList:
 
@@ -139,14 +142,12 @@ def stack_arrays(array_list: list):
 
   return stacked
 
-def scale_points(small_img_width: int, small_img_height: int, img_array: list, points: list[tuple[int, int]]):
+def scale_flip_points(small_img_width: int, small_img_height: int, img_array: list, points: list[tuple[int, int]]):
   """
     Scale the coordinates from a smaller image to the full sized fits so we know the positions of the coords on the 2dnumpy array
     Returns the list of tuple points with coords scaled for the numpy array
   """
-  print(f"small_img_width: {small_img_width}, small_img_height: {small_img_height}")
   large_height, large_width = np.shape(img_array)
-  print(f"large_height: {large_height}, large_width: {large_width}")
 
   # If the aspect ratios don't match we can't be certain where the point was
   if small_img_width / small_img_height != large_width / large_height:
@@ -154,11 +155,10 @@ def scale_points(small_img_width: int, small_img_height: int, img_array: list, p
 
   width_scale = large_width / small_img_width
   height_scale = large_height / small_img_height
-  print(f"width_scale: {width_scale}, height_scale: {height_scale}")
 
   points_array = np.array(points)
-  print(f"points_array: {points_array}")
   scaled_points = np.int_(points_array * [width_scale, height_scale])
-  print(f"scaled_points: {scaled_points}")
+  # html origin is top left, numpy origin is bottom left, so we need to flip the y axis
+  scaled_points[:, 1] = large_height - scaled_points[:, 1]
 
   return scaled_points

--- a/datalab/settings.py
+++ b/datalab/settings.py
@@ -135,7 +135,7 @@ DATALAB_OPERATION_BUCKET = os.getenv('DATALAB_OPERATION_BUCKET', 'datalab-operat
 
 # Datalab Archive
 ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://archive-api.lco.global')
-AUTH_TOKEN = os.getenv('AUTH_TOKEN')
+ARCHIVE_API_TOKEN = os.getenv('ARCHIVE_API_TOKEN')
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/datalab/settings.py
+++ b/datalab/settings.py
@@ -134,7 +134,8 @@ DRAMATIQ_TASKS_DATABASE = 'default'
 DATALAB_OPERATION_BUCKET = os.getenv('DATALAB_OPERATION_BUCKET', 'datalab-operation-output-bucket')
 
 # Datalab Archive
-ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://datalab-archive.photonranch.org')
+ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://archive-api.lco.global')
+AUTH_TOKEN = os.getenv('AUTH_TOKEN')
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases


### PR DESCRIPTION
A couple of fixes in this PR

**Line Analysis**
There was a bug caused by the difference between origins in the html image and fits image. The html's origin is in the top left, while the fit's is in the bottom left. Now in `scale_flip_points` we are accounting for this by finding the difference from the total height which flips the y value.

**Median Bug**
Jon mentioned that medians were failing in prod with a memmap error. As I've worked more with astropy fits I learned that astropy already has a built in form of memmap so this was redundant and also probably causing an error. Tested on local this works fine, but we'll have to see once its deployed.

**Local Dev Auth Token**
so that you can work on datalab locally we now need to pass your token to request calls. There is an added setting in `settings.py` called `AUTH_TOKEN`.  You'll need to use the same token that is used for archive calls in the UI. 

**Error Messages**
changing some try/except blocks to properly catch errors and print out messages. 