### PR TITLE
wcs solution for coords and length of line analysis, dev warning for auth token

### DIFF
--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -1,4 +1,5 @@
 from skimage.measure import profile_line
+from astropy.wcs import WCS
 
 from datalab.datalab_session.util import scale_points
 from datalab.datalab_session.util import get_hdu
@@ -9,9 +10,32 @@ def line_profile(input: dict):
     Creates an array of luminosity values and the length of the line in arcseconds
   """
   sci_hdu = get_hdu(input['basename'], 'SCI')
-
+  
   x_points, y_points = scale_points(input["height"], input["width"], sci_hdu.data.shape[0], sci_hdu.data.shape[1], x_points=[input["x1"], input["x2"]], y_points=[input["y1"], input["y2"]])
+  
+  # Line profile and distance in arcseconds
   line_profile = profile_line(sci_hdu.data, (x_points[0], y_points[0]), (x_points[1], y_points[1]), mode="constant", cval=-1)
-  arcsec = len(line_profile) * sci_hdu.header["PIXSCALE"]
+  
 
-  return {"line_profile": line_profile, "arcsec": arcsec}
+  # Calculations for coordinates and angular distance
+  try: 
+    wcs = WCS(sci_hdu.header)
+
+    start_sky_coord = wcs.pixel_to_world(x_points[0], y_points[0])
+    end_sky_coord = wcs.pixel_to_world(x_points[1], y_points[1])
+
+    arcsec_angle = start_sky_coord.separation(end_sky_coord).arcsecond
+
+    start_coords = [start_sky_coord.ra.deg, start_sky_coord.dec.deg]
+    end_coords = [end_sky_coord.ra.deg, end_sky_coord.dec.deg]
+
+  except Exception as e:
+    print(e)
+    error = f'{input["basename"]} does not have a valid WCS header'
+    # if theres no valid WCS solution then we default to using pixscale to calculate the angle, and no coordinates
+    start_coords = None
+    end_coords = None
+    arcsec_angle = len(line_profile) * sci_hdu.header["PIXSCALE"]
+
+  return {"line_profile": line_profile, "arcsec": arcsec_angle, "start_coords": start_coords, "end_coords": end_coords}
+  

--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -31,8 +31,8 @@ def line_profile(input: dict):
     end_coords = [end_sky_coord.ra.deg, end_sky_coord.dec.deg]
 
   except WcsError as e:
-    print(error, e)
     error = f'{input["basename"]} does not have a valid WCS header'
+    print(error, e)
     # if theres no valid WCS solution then we default to using pixscale to calculate the angle, and no coordinates
     start_coords = None
     end_coords = None

--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -1,5 +1,6 @@
 from skimage.measure import profile_line
 from astropy.wcs import WCS
+from astropy.wcs import WcsError
 
 from datalab.datalab_session.util import scale_points
 from datalab.datalab_session.util import get_hdu
@@ -29,8 +30,8 @@ def line_profile(input: dict):
     start_coords = [start_sky_coord.ra.deg, start_sky_coord.dec.deg]
     end_coords = [end_sky_coord.ra.deg, end_sky_coord.dec.deg]
 
-  except Exception as e:
-    print(e)
+  except WcsError as e:
+    print(error, e)
     error = f'{input["basename"]} does not have a valid WCS header'
     # if theres no valid WCS solution then we default to using pixscale to calculate the angle, and no coordinates
     start_coords = None
@@ -38,4 +39,3 @@ def line_profile(input: dict):
     arcsec_angle = len(line_profile) * sci_hdu.header["PIXSCALE"]
 
   return {"line_profile": line_profile, "arcsec": arcsec_angle, "start_coords": start_coords, "end_coords": end_coords}
-  

--- a/datalab/settings.py
+++ b/datalab/settings.py
@@ -137,6 +137,8 @@ DATALAB_OPERATION_BUCKET = os.getenv('DATALAB_OPERATION_BUCKET', 'datalab-operat
 # Datalab Archive
 ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://archive-api.lco.global')
 ARCHIVE_API_TOKEN = os.getenv('ARCHIVE_API_TOKEN')
+if not ARCHIVE_API_TOKEN:
+    print("WARNING: ARCHIVE_API_TOKEN is missing from the environment.")
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/datalab/settings.py
+++ b/datalab/settings.py
@@ -139,6 +139,7 @@ ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://archive-api.lco.global')
 ARCHIVE_API_TOKEN = os.getenv('ARCHIVE_API_TOKEN')
 if not ARCHIVE_API_TOKEN:
     print("WARNING: ARCHIVE_API_TOKEN is missing from the environment.")
+    exit()
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases


### PR DESCRIPTION
Now using a WCS solution to find both the length of the line and the coordinates of the start and endpoints which is supposed to be more accurate than the pixelscale. Though if the wcs solution doesn't work then we default to using pixscale for the line.

Also added a qol check for the auth token to warn the user if they don't have their api auth token in their local dev enviorment