### PR TITLE
Error Task, Error message returns, Better Except Cases, Dramatiq Retry Limit

### DIFF
--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -98,7 +98,6 @@ class BaseDataOperation(ABC):
     def set_failed(self, message: str):
         self.set_status('FAILED')
         self.set_message(message)
-        self.set_percent_completion(1.0)
 
     # percent lets you allocate a fraction of the operation that this takes up in time
     # cur_percent is the current completion of the operation

--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -1,10 +1,9 @@
 from abc import ABC, abstractmethod
 import hashlib
 import json
-import os
 import tempfile
-from django.core.cache import cache
 
+from django.core.cache import cache
 from fits2image.conversions import fits_to_jpg
 from astropy.io import fits
 import numpy as np
@@ -95,8 +94,13 @@ class BaseDataOperation(ABC):
 
     def get_output(self) -> dict:
         return cache.get(f'operation_{self.cache_key}_output')
+    
+    def set_failed(self, message: str):
+        self.set_status('FAILED')
+        self.set_message(message)
+        self.set_percent_completion(1.0)
 
-    # percent lets you alocate a fraction of the operation that this takes up in time
+    # percent lets you allocate a fraction of the operation that this takes up in time
     # cur_percent is the current completion of the operation
     def create_and_store_fits(self, hdu_list: fits.HDUList, percent=None, cur_percent=None) -> list:
         if not type(hdu_list) == list:

--- a/datalab/datalab_session/data_operations/error.py
+++ b/datalab/datalab_session/data_operations/error.py
@@ -1,0 +1,52 @@
+import builtins
+import logging
+
+from requests.exceptions import RequestException
+from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+
+log=logging.getLogger()
+log.setLevel(logging.INFO)
+
+class ErrorOperation(BaseDataOperation):
+  @staticmethod
+  def name():
+    return 'Error'
+  
+  @staticmethod
+  def description():
+    return """The Error will raise an error in the dramatiq worker!"""
+  
+  @staticmethod
+  def wizard_description():
+    return {
+      'name': 'Error',
+      'description': 'The Error will raise an error in the dramatiq worker!',
+      'category': 'test',
+      'inputs': {
+        'input_files': {
+            'name': 'Input Files',
+            'description': 'The input files to operate on',
+            'type': 'file',
+            'minimum': 1,
+            'maximum': 999
+        },
+        'Error Type': {
+          'name': 'Error Type',
+          'description': 'The type of error to raise, should be a python error type',
+          'type': 'text',
+        },
+        'Error Message': {
+          'name': 'Error Message',
+          'description': 'The message to include with the error',
+          'type': 'text',
+        }
+      }
+    }
+  
+  def operate(self):
+    error_type_name = self.input_data.get('Error Type')
+    error_type = getattr(builtins, error_type_name, None)
+    if not error_type or not issubclass(error_type, BaseException):
+      raise RequestException(f'Unknown Error Type: {error_type_name}')
+    else:
+      raise error_type(self.input_data.get('Error Message', 'No Error Message, Default Error Message!'))

--- a/datalab/datalab_session/tasks.py
+++ b/datalab/datalab_session/tasks.py
@@ -1,19 +1,19 @@
-import logging
-
 import dramatiq
 
 from datalab.datalab_session.data_operations.utils import available_operations
-from datalab.datalab_session.util import get_presigned_url, key_exists
+from requests.exceptions import RequestException
 
-log = logging.getLogger()
-log.setLevel(logging.INFO)
+# Retry network connection errors 3 times, all other exceptions are not retried
+def should_retry(retries_so_far, exception):
+    return retries_so_far < 3 and isinstance(exception, RequestException)
 
-#TODO: Perhaps define a pipeline that can take the output of one data operation and upload to a s3 bucket, indicate success, etc...
-
-@dramatiq.actor()
+@dramatiq.actor(retry_when=should_retry)
 def execute_data_operation(data_operation_name: str, input_data: dict):
     operation_class = available_operations().get(data_operation_name)
     if operation_class is None:
         raise NotImplementedError("Operation not implemented!")
     else:
-        operation_class(input_data).operate()
+        try:
+            operation_class(input_data).operate()
+        except Exception as e:
+            operation_class(input_data).set_failed(str(e))

--- a/datalab/datalab_session/viewsets.py
+++ b/datalab/datalab_session/viewsets.py
@@ -1,11 +1,9 @@
 from rest_framework import viewsets
-from rest_framework.decorators import action
 from django_filters.rest_framework import DjangoFilterBackend
 
 from datalab.datalab_session.serializers import DataSessionSerializer, DataOperationSerializer
 from datalab.datalab_session.models import DataSession, DataOperation
 from datalab.datalab_session.filters import DataSessionFilterSet
-from datalab.datalab_session.tasks import execute_data_operation
 from datalab.datalab_session.data_operations.utils import available_operations
 
 


### PR DESCRIPTION
Added a `set_failed` method to `data_operation` so that at any point the data operation can set a failure state along with a message of what happened. 

New Error Task that allows you to test a dramatiq worker throwing various errors. Should be hidden in the final version but its a useful testing tool for now. 

In `tasks.py` where Django sets off the dramatiq workers added a `retry_when` parameter that retries operations if there are networking errors 3 times, otherwise the worker fails and stops. Before workers would indefinitely try to re run the task and the front-end would keep polling. 
In this file we also have the try `operate` except block that picks up the errors from the dramatiq workers. Setting failed inside the workers ins't possible since a lot of errors come from the `util` file which doesn't have access to the operation cache, so the workers are just responsible for raising the right error and message and then the runner will set the failed state which seemed to make the most sense.

Speaking of the util's file I added more error raising for some of the most common problems
- missing fits
- missing header
- networking errors
Also the error messages are sent all the way to the front-end so I tried to word them in an easily readable way




