### PR TITLE
Checking for source of inputs to determine where to fetch fits file from

### DIFF
--- a/datalab/datalab_session/tasks.py
+++ b/datalab/datalab_session/tasks.py
@@ -1,7 +1,11 @@
 import dramatiq
+import logging
 
 from datalab.datalab_session.data_operations.utils import available_operations
 from requests.exceptions import RequestException
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
 
 # Retry network connection errors 3 times, all other exceptions are not retried
 def should_retry(retries_so_far, exception):
@@ -16,4 +20,5 @@ def execute_data_operation(data_operation_name: str, input_data: dict):
         try:
             operation_class(input_data).operate()
         except Exception as e:
+            log.error(f"Error executing {data_operation_name}: {type(e).__name__}:{e}")
             operation_class(input_data).set_failed(str(e))

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -133,10 +133,6 @@ def get_hdu(basename: str, extension: str = 'SCI', source: str = 'archive') -> l
       case 'archive':
         fits_url = get_archive_url(basename)
       case 'datalab':
-        # as of July 2024 we don't make any other headers for datalab outputs other than SCI
-        if extension != 'SCI':
-          raise ValueError(f"Extension {extension} not available for source {source}")
-
         s3_folder_path = f'{basename.split("-")[0]}/{basename}.fits'
         fits_url = get_s3_url(s3_folder_path)
       case _:


### PR DESCRIPTION
Before attempting to perform a data operation on outputs from datalab would fail because the function that downloaded the fits file would only grab from the archive instead of the datalab output s3. Now it checks what the source of the image is and retrieves it from the right bucket.

`get_hdu()` now has an additional parameter `source` that it will check and then depending on the name handle with a match case statement. This is so in the future if we want to accept other sources and they have different data retrieval methods we can easily add them as a case.

Additional changes:
- Can now run operations that have failed before if you want to try again
- Return a url to the fits file for frontend
- Replace some duplicate code with `get_hdu()`
- Logging of Errors for Devs
- Changed name of `get_presigned_url()` to `get_s3_url()` to better describe the actual function
- Changed name of `get_archive_from_basename()` to `get_archive_url()` to be consistent and more clear (we're not getting the archive)
- add name `SCI` to `imageHDU` creation since it was naming the HDU as `1` causing trying to access the `SCI` header to fail