### PR TITLE
Feature/rgb composite

### DIFF
--- a/datalab/datalab_session/data_operations/long.py
+++ b/datalab/datalab_session/data_operations/long.py
@@ -23,7 +23,7 @@ class LongOperation(BaseDataOperation):
                     'description': 'The input files to operate on',
                     'type': 'file',
                     'minimum': 1,
-                    'maxmimum': 999
+                    'maximum': 999
                 },
                 'duration': {
                     'name': 'Duration',

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -33,7 +33,7 @@ The output is a median image for the n input images. This operation is commonly 
                     'description': 'The input files to operate on',
                     'type': 'file',
                     'minimum': 1,
-                    'maxmimum': 999
+                    'maximum': 999
                 }
             }
         }
@@ -52,9 +52,9 @@ The output is a median image for the n input images. This operation is commonly 
             # using the numpy library's median method
             median = np.median(stacked_data, axis=2)
 
-            hdu_list = create_fits(self.cache_key, median)
+            fits_file = create_fits(self.cache_key, median)
 
-            output = self.create_and_store_fits(hdu_list, percent=0.6, cur_percent=0.4)
+            output = self.create_jpg_output(fits_file, percent=0.6, cur_percent=0.4)
 
             output =  {'output_files': output}
         else:

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
-from datalab.datalab_session.util import create_fits, stack_arrays
+from datalab.datalab_session.util import create_fits, stack_arrays, create_jpgs, save_fits_and_thumbnails
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -54,9 +54,11 @@ The output is a median image for the n input images. This operation is commonly 
 
             fits_file = create_fits(self.cache_key, median)
 
-            output = self.create_jpg_output(fits_file, percent=0.6, cur_percent=0.4)
+            large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, fits_file)
 
-            output =  {'output_files': output}
+            output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path)
+
+            output =  {'output_files': [output_file]}
         else:
             output = {'output_files': []}
 

--- a/datalab/datalab_session/data_operations/noop.py
+++ b/datalab/datalab_session/data_operations/noop.py
@@ -22,7 +22,7 @@ class NoOperation(BaseDataOperation):
                     'description': 'The input files to operate on',
                     'type': 'file',
                     'minimum': 1,
-                    'maxmimum': 999
+                    'maximum': 999
                 },
                 'scalar_parameter_1': {
                     'name': 'Scalar Parameter 1',

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -63,6 +63,7 @@ class RGB_Stack(BaseDataOperation):
             fits_paths = []
             for file in rgb_input_list:
                 fits_paths.append(get_fits(file.get('basename')))
+                self.set_percent_completion(self.get_percent_completion() + 0.2)
             
             output = self.create_jpg_output(fits_paths, percent=0.9, cur_percent=0.0, color=True)
 

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -1,0 +1,82 @@
+import logging
+import tempfile
+
+from fits2image.conversions import fits_to_jpg
+
+from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+from datalab.datalab_session.util import add_file_to_bucket, get_fits
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+
+class RGB_Stack(BaseDataOperation):
+    
+    @staticmethod
+    def name():
+        return 'RGB Stack'
+    
+    @staticmethod
+    def description():
+        return """The RGB Stack operation takes in 3 input images which have red, green, and blue filters and creates a colored image by compositing them on top of each other."""
+
+    @staticmethod
+    def wizard_description():
+        return {
+            'name': RGB_Stack.name(),
+            'description': RGB_Stack.description(),
+            'category': 'image',
+            'inputs': {
+                'red_input': {
+                    'name': 'Red Filter',
+                    'description': 'Three images to stack their RGB values',
+                    'type': 'file',
+                    'minimum': 1,
+                    'maximum': 1,
+                    'filter': ['rp', 'r']
+                },
+                'green_input': {
+                    'name': 'Green Filter',
+                    'description': 'Three images to stack their RGB values',
+                    'type': 'file',
+                    'minimum': 1,
+                    'maximum': 1,
+                    'filter': ['V']
+                },
+                'blue_input': {
+                    'name': 'Blue Filter',
+                    'description': 'Three images to stack their RGB values',
+                    'type': 'file',
+                    'minimum': 1,
+                    'maximum': 1,
+                    'filter': ['B']
+                },
+                'random_seed': {
+                    'name': 'Seed',
+                    'description': 'so I can test this without it being cached',
+                    'type': 'number',
+                    'minimum': 0,
+                    'maximum': 99999.0,
+                    'default': 60.0
+                }
+            }
+        }
+    
+    def operate(self):
+        rgb_input_list = self.input_data['red_input'] + self.input_data['green_input'] + self.input_data['blue_input']
+
+        if len(rgb_input_list) == 3:
+            log.info(f'Executing RGB Stack operation on files: {rgb_input_list}')
+
+            fits_paths = []
+            for file in rgb_input_list:
+                fits_paths.append(get_fits(file.get('basename')))
+            
+            output = self.create_jpg_output(fits_paths, percent=0.9, cur_percent=0.0, color=True)
+        else:
+            output = {'output_files': []}
+            raise ValueError('RGB Stack operation requires exactly 3 input files')
+
+        self.set_percent_completion(1.0)
+        self.set_output(output)
+        log.info(f'RGB Stack output: {self.get_output()}')

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -41,7 +41,7 @@ class RGB_Stack(BaseDataOperation):
                     'type': 'file',
                     'minimum': 1,
                     'maximum': 1,
-                    'filter': ['V']
+                    'filter': ['V', 'gp']
                 },
                 'blue_input': {
                     'name': 'Blue Filter',
@@ -73,6 +73,8 @@ class RGB_Stack(BaseDataOperation):
                 fits_paths.append(get_fits(file.get('basename')))
             
             output = self.create_jpg_output(fits_paths, percent=0.9, cur_percent=0.0, color=True)
+
+            output =  {'output_files': output}
         else:
             output = {'output_files': []}
             raise ValueError('RGB Stack operation requires exactly 3 input files')

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -50,14 +50,6 @@ class RGB_Stack(BaseDataOperation):
                     'minimum': 1,
                     'maximum': 1,
                     'filter': ['B']
-                },
-                'random_seed': {
-                    'name': 'Seed',
-                    'description': 'so I can test this without it being cached',
-                    'type': 'number',
-                    'minimum': 0,
-                    'maximum': 99999.0,
-                    'default': 60.0
                 }
             }
         }

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -156,15 +156,13 @@ def get_hdu(basename: str, extension: str = 'SCI', source: str = 'archive') -> l
   
   return extension
 
-def fits_dimensions(fits_file) -> tuple:
-  hdu = fits.open(fits_file)
-  height, width = hdu[1].shape
-  return height, width
+def get_fits_dimensions(fits_file, extension: str = 'SCI') -> tuple:
+  return fits.open(fits_file)[extension].shape
 
-def create_fits(key: str, image_arr: np.ndarray) -> fits.HDUList:
+def create_fits(key: str, image_arr: np.ndarray) -> str:
   """
   Creates a fits file with the given key and image array
-  Returns the HDUList and the dimensions of the image
+  Returns the the path to the fits_file
   """
 
   header = fits.Header([('KEY', key)])

--- a/datalab/datalab_session/util.py
+++ b/datalab/datalab_session/util.py
@@ -7,9 +7,10 @@ import urllib.request
 import boto3
 from astropy.io import fits
 import numpy as np
+from botocore.exceptions import ClientError
 
 from django.conf import settings
-from botocore.exceptions import ClientError
+from fits2image.conversions import fits_to_jpg
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -174,6 +175,47 @@ def create_fits(key: str, image_arr: np.ndarray) -> str:
   hdu_list.writeto(fits_path)
 
   return fits_path
+
+def create_jpgs(cache_key, fits_paths: str, color=False) -> list:
+    """
+    Create jpgs from fits files and save them to S3
+    If using the color option fits_paths need to be in order R, G, B
+    percent and cur_percent are used to update the progress of the operation
+    """
+
+    if not isinstance(fits_paths, list):
+        fits_paths = [fits_paths]
+
+    # create the jpgs from the fits files
+    large_jpg_path      = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-large.jpg').name
+    thumbnail_jpg_path  = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-small.jpg').name
+
+    max_height, max_width = max(get_fits_dimensions(path) for path in fits_paths)
+
+    fits_to_jpg(fits_paths, large_jpg_path, width=max_width, height=max_height, color=color)
+    fits_to_jpg(fits_paths, thumbnail_jpg_path, color=color)
+
+    return large_jpg_path, thumbnail_jpg_path
+
+def save_fits_and_thumbnails(cache_key, fits_path, large_jpg_path, thumbnail_jpg_path, index=None):
+    """
+    Save Fits and Thumbnails in S3 Buckets, Returns the URLs in an output object
+    """
+    bucket_key = f'{cache_key}/{cache_key}-{index}' if index else f'{cache_key}/{cache_key}'
+
+    fits_url            = add_file_to_bucket(f'{bucket_key}.fits', fits_path)
+    large_jpg_url       = add_file_to_bucket(f'{bucket_key}-large.jpg', large_jpg_path)
+    thumbnail_jpg_url   = add_file_to_bucket(f'{bucket_key}-small.jpg', thumbnail_jpg_path)
+    
+    output_file = dict({
+        'fits_url': fits_url,
+        'large_url': large_jpg_url,
+        'thumbnail_url': thumbnail_jpg_url,
+        'basename': f'{cache_key}',
+        'source': 'datalab'}
+    )
+    
+    return output_file
 
 def stack_arrays(array_list: list):
   """


### PR DESCRIPTION
Adds a RGB composite operation that creates a colored image. Updates to util functions to improve their flexibility and shared functionality across operations.

- `create_and_store_fits()` renamed to `create_jpg_output()`
- `create_and_store_fits()` takes a `color` param that will set the `fits2img` color option to true, also stacks the fits files into one
- `create_jpg_output()` no longer creates the fits file as well this responsibility is moved to `create_fits()`
- `create_jpg_output()` accepts a fits file instead of a `hdu_list`
- `create_fits()` writes a fits file out instead of creating a `hdu_list` object
- fixed maximum spelling
- split off the fits fetching from `get_hdu` into its own function `get_fits` for operations that need the whole fits file
- added util function to find fits dimensions `fits_dimensions`