### PR TITLE
ClientAlertException added, tasks catch this error

### DIFF
--- a/datalab/datalab_session/data_operations/error.py
+++ b/datalab/datalab_session/data_operations/error.py
@@ -3,6 +3,7 @@ import logging
 
 from requests.exceptions import RequestException
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+from datalab.datalab_session.exceptions import ClientAlertException
 
 log=logging.getLogger()
 log.setLevel(logging.INFO)
@@ -47,6 +48,6 @@ class ErrorOperation(BaseDataOperation):
     error_type_name = self.input_data.get('Error Type')
     error_type = getattr(builtins, error_type_name, None)
     if not error_type or not issubclass(error_type, BaseException):
-      raise RequestException(f'Unknown Error Type: {error_type_name}')
+      raise ClientAlertException(f'Unknown Error Type: {error_type_name}')
     else:
       raise error_type(self.input_data.get('Error Message', 'No Error Message, Default Error Message!'))

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+from datalab.datalab_session.exceptions import ClientAlertException
 from datalab.datalab_session.file_utils import create_fits, stack_arrays, create_jpgs
 from datalab.datalab_session.s3_utils import save_fits_and_thumbnails
 
@@ -43,25 +44,25 @@ The output is a median image for the n input images. This operation is commonly 
 
         input = self.input_data.get('input_files', [])
 
+        if len(input) <= 1:
+            raise ClientAlertException('Median needs at least 2 files')
+
         log.info(f'Executing median operation on {len(input)} files')
 
-        if len(input) > 0:
-            image_data_list = self.get_fits_npdata(input, percent=0.4, cur_percent=0.0)
+        image_data_list = self.get_fits_npdata(input, percent=0.4, cur_percent=0.0)
 
-            stacked_data = stack_arrays(image_data_list)
+        stacked_data = stack_arrays(image_data_list)
 
-            # using the numpy library's median method
-            median = np.median(stacked_data, axis=2)
+        # using the numpy library's median method
+        median = np.median(stacked_data, axis=2)
 
-            fits_file = create_fits(self.cache_key, median)
+        fits_file = create_fits(self.cache_key, median)
 
-            large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, fits_file)
+        large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, fits_file)
 
-            output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path)
+        output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path)
 
-            output =  {'output_files': [output_file]}
-        else:
-            output = {'output_files': []}
+        output =  {'output_files': [output_file]}
 
         self.set_percent_completion(1.0)
         self.set_output(output)

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -3,6 +3,7 @@ import logging
 from astropy.io import fits
 
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+from datalab.datalab_session.exceptions import ClientAlertException
 from datalab.datalab_session.file_utils import get_fits, stack_arrays, create_fits, create_jpgs
 from datalab.datalab_session.s3_utils import save_fits_and_thumbnails
 
@@ -77,7 +78,7 @@ class RGB_Stack(BaseDataOperation):
             output =  {'output_files': [output_file]}
         else:
             output = {'output_files': []}
-            raise ValueError('RGB Stack operation requires exactly 3 input files')
+            raise ClientAlertException('RGB Stack operation requires exactly 3 input files')
 
         self.set_percent_completion(1.0)
         self.set_output(output)

--- a/datalab/datalab_session/exceptions.py
+++ b/datalab/datalab_session/exceptions.py
@@ -1,0 +1,5 @@
+class ClientAlertException(Exception):
+  """Custom exception for errors to be shown on the client side."""
+  def __init__(self, message):
+    self.message = message
+    super().__init__(message)

--- a/datalab/datalab_session/file_utils.py
+++ b/datalab/datalab_session/file_utils.py
@@ -5,6 +5,7 @@ from astropy.io import fits
 import numpy as np
 from fits2image.conversions import fits_to_jpg, fits_to_tif
 
+from datalab.datalab_session.exceptions import ClientAlertException
 from datalab.datalab_session.s3_utils import get_fits, add_file_to_bucket
 
 log = logging.getLogger()
@@ -23,7 +24,7 @@ def get_hdu(basename: str, extension: str = 'SCI', source: str = 'archive') -> l
   try:
     extension = hdu[extension]
   except KeyError:
-    raise KeyError(f"{extension} Header not found in fits file {basename}")
+    raise ClientAlertException(f"{extension} Header not found in fits file {basename}")
   
   return extension
 

--- a/datalab/datalab_session/tasks.py
+++ b/datalab/datalab_session/tasks.py
@@ -4,6 +4,8 @@ import logging
 from datalab.datalab_session.data_operations.utils import available_operations
 from requests.exceptions import RequestException
 
+from datalab.datalab_session.exceptions import ClientAlertException
+
 log = logging.getLogger()
 log.setLevel(logging.INFO)
 
@@ -19,6 +21,6 @@ def execute_data_operation(data_operation_name: str, input_data: dict):
     else:
         try:
             operation_class(input_data).operate()
-        except Exception as e:
-            log.error(f"Error executing {data_operation_name}: {type(e).__name__}:{e}")
+        except ClientAlertException as e:
+            log.error(f"Client Error executing {data_operation_name}: {type(e).__name__}:{e}")
             operation_class(input_data).set_failed(str(e))

--- a/datalab/datalab_session/tasks.py
+++ b/datalab/datalab_session/tasks.py
@@ -21,6 +21,9 @@ def execute_data_operation(data_operation_name: str, input_data: dict):
     else:
         try:
             operation_class(input_data).operate()
-        except ClientAlertException as e:
-            log.error(f"Client Error executing {data_operation_name}: {type(e).__name__}:{e}")
-            operation_class(input_data).set_failed(str(e))
+        except ClientAlertException as error:
+            log.error(f"Client Error executing {data_operation_name}: {error}")
+            operation_class(input_data).set_failed(str(error))
+        except Exception as error:
+            log.exception(error)
+            operation_class(input_data).set_failed("An unknown error ocurred, contact developers if this persists.")


### PR DESCRIPTION
Previously in `tasks.py` all exceptions were caught and displayed to the end user by using the `set_failed` method. This wasn't ideal as normal python errors when developing were caught, wouldn't print to the console, and were shown on the UI. All of which are not ideal. 

Now there is a custom exception class `ClientAlertException` for errors that we want to catch AND should be shown to the user on the frontend.

This PR was made in anticipation of the datalab hackathon, we don't want the developers errors to not be printed out with their full logs and only shown on the UI