### PR TITLE
find_module deprecated in 3.12 replacing with import_module

### DIFF
--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -1,4 +1,4 @@
-name: Django Test
+name: Test Datalab
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -2,6 +2,7 @@ name: Django Test
 
 on:
   push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -9,6 +9,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     
     steps:
     - name: Checkout
@@ -16,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with: 
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install Poetry
       run: |
         python -m pip install --upgrade pip

--- a/datalab/datalab_session/data_operations/utils.py
+++ b/datalab/datalab_session/data_operations/utils.py
@@ -1,5 +1,6 @@
 from pkgutil import walk_packages
 import inspect
+from importlib import import_module
 from django.utils.module_loading import import_string
 from datalab.datalab_session import data_operations
 
@@ -8,7 +9,7 @@ def available_operations():
     operations = {}
     base_operation = import_string('datalab.datalab_session.data_operations.data_operation.BaseDataOperation')
     for (loader, module_name, _) in walk_packages(data_operations.__path__):
-        module = loader.find_module(module_name).load_module()
+        module = import_module(f'{data_operations.__name__}.{module_name}')
         members = inspect.getmembers(module, inspect.isclass)
         for member in members:
             if member[0] != 'BaseDataOperation' and issubclass(member[1], base_operation):


### PR DESCRIPTION
Project would not work on 3.12 even though in the toml it says >=3.10 <4, this fixes a deprecated method in 3.12 with its new form