### PR TITLE
Use Archive Token from requests instead of setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ The project is configured to use a local sqlite database. You can change that to
 ```
     ./manage.py migrate
 ```
-Get your auth token from the UI by signing in with your LCO credentials and checking your cookies for an auth-token. Once you have it export it to your dev enviorment like
-```
-    export ARCHIVE_API_TOKEN=<your-auth-token>
-```
 Start up a Redis Server that will faciliate caching as well as the rabbitmq queue. To do this make sure you have Redis installed and then start a server at port 6379
 ```
     redis-server

--- a/datalab/datalab_session/s3_utils.py
+++ b/datalab/datalab_session/s3_utils.py
@@ -7,7 +7,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 from django.conf import settings
-
+from django.core.cache import cache
 from datalab.datalab_session.exceptions import ClientAlertException
 
 log = logging.getLogger()
@@ -92,7 +92,7 @@ def get_archive_url(basename: str, archive: str = settings.ARCHIVE_API) -> dict:
   query_params = {'basename_exact': basename }
 
   headers = {
-    'Authorization': f'Token {settings.ARCHIVE_API_TOKEN}'
+    'Authorization': cache.get('archive_token'),
   }
 
   response = requests.get(archive + '/frames/', params=query_params, headers=headers)

--- a/datalab/middleware.py
+++ b/datalab/middleware.py
@@ -1,0 +1,16 @@
+from django.core.cache import cache
+
+class CaptureTokenMiddleware:
+    """
+    Middleware to capture the Archive Authorization token from the request headers and store it in the cache
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        token = request.headers.get('Authorization')
+        if token:
+          cache.set('archive_token', token, timeout=None)
+
+        response = self.get_response(request)
+        return response

--- a/datalab/settings.py
+++ b/datalab/settings.py
@@ -79,6 +79,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'datalab.middleware.CaptureTokenMiddleware',
 ]
 
 ROOT_URLCONF = 'datalab.urls'
@@ -136,9 +137,6 @@ DATALAB_OPERATION_BUCKET = os.getenv('DATALAB_OPERATION_BUCKET', 'datalab-operat
 
 # Datalab Archive
 ARCHIVE_API = os.getenv('ARCHIVE_API', 'https://archive-api.lco.global')
-ARCHIVE_API_TOKEN = os.getenv('ARCHIVE_API_TOKEN')
-if not ARCHIVE_API_TOKEN:
-    print("WARNING: ARCHIVE_API_TOKEN is missing from the environment.")
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/datalab/urls.py
+++ b/datalab/urls.py
@@ -30,12 +30,12 @@ operations_router.register(r'operations', DataOperationViewSet, basename='datase
 api_urlpatterns = ([
     re_path(r'^', include(router.urls)),
     re_path(r'^', include(operations_router.urls)),
+    path(r'analysis/<slug:action>/', AnalysisView.as_view(), name='analysis'),
+    path('available_operations/', OperationOptionsApiView.as_view(), name='available_operations')
 ], 'api')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     re_path(r'^api/', include(api_urlpatterns)),
-    path(r'api/analysis/<slug:action>/', AnalysisView.as_view(), name='analysis'),
-    path('api/available_operations/', OperationOptionsApiView.as_view(), name='available_operations'),
     re_path(r'^authprofile/', include(authprofile_urls)),
 ]


### PR DESCRIPTION
Archive Token from Request
- add token capture middleware that grabs the authorization header from the request to store in a cache and use it when making archive requests in `get_archive_url`
- update readme now that manual setting no longer needed for local dev
- remove ARCHIVE_TOKEN from settings since its no longer needed

bonus:
- moved api paths to api group, since they also are under the `api/` tree

Warning: When deploying this PR remember to remove the ARCHIVE TOKEN setting from the helm charts or wherever we populate settings