### PR TITLE
Adds normalization operation and corrects typo

### DIFF
--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -53,7 +53,7 @@ class BaseDataOperation(ABC):
         """
 
     def perform_operation(self):
-        """ The generic method to perform perform the operation if its not in progress """
+        """ The generic method to perform the operation if its not in progress """
         status = self.get_status()
         if status == 'PENDING' or status == 'FAILED':
             self.set_status('IN_PROGRESS')

--- a/datalab/datalab_session/data_operations/normalization.py
+++ b/datalab/datalab_session/data_operations/normalization.py
@@ -20,7 +20,7 @@ class Normalization(BaseDataOperation):
     def description():
         return """The normalize operation takes in 1..n input images and calculates each image's median value and divides every pixel by that value.
 
-The output is a normalized image for the n input images. This operation is commonly used as a precursor step for flat removal."""
+The output is a normalized image. This operation is commonly used as a precursor step for flat removal."""
 
     @staticmethod
     def wizard_description():
@@ -43,23 +43,24 @@ The output is a normalized image for the n input images. This operation is commo
 
         input = self.input_data.get('input_files', [])
 
-        log.info(f'Executing normalization operation on {len(input)} file(s) {input}')
+        log.info(f'Executing normalization operation on {len(input)} file(s)')
 
-        image_data_list = self.get_fits_npdata(input, percent=0.4, cur_percent=0.0)
-        log.info(f'image data list: {image_data_list}')
+        image_data_list = self.get_fits_npdata(input)
+        self.set_percent_completion(0.40)
+
         output_files = []
-        for i, image in enumerate(image_data_list):
+        for index, image in enumerate(image_data_list):
             median = np.median(image)
             normalized_image = image / median
+
             fits_file = create_fits(self.cache_key, normalized_image)
-            log.info(f'fits_file: {fits_file}')
             large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, fits_file)
-            output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path, index=i)
+            output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path, index=index)
             output_files.append(output_file)
-            log.info(f'x: {output_files}')
+
+            self.set_percent_completion(self.get_percent_completion() + .40 * (index + 1) / len(input))
             
         output =  {'output_files': output_files}
 
-        self.set_percent_completion(1.0)
         self.set_output(output)
         log.info(f'Normalization output: {self.get_output()}')

--- a/datalab/datalab_session/data_operations/normalization.py
+++ b/datalab/datalab_session/data_operations/normalization.py
@@ -1,0 +1,65 @@
+import logging
+
+import numpy as np
+
+from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
+from datalab.datalab_session.file_utils import create_fits, create_jpgs
+from datalab.datalab_session.s3_utils import save_fits_and_thumbnails
+
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+
+class Normalization(BaseDataOperation):
+    
+    @staticmethod
+    def name():
+        return 'Normalization'
+    
+    @staticmethod
+    def description():
+        return """The normalize operation takes in 1..n input images and calculates each image's median value and divides every pixel by that value.
+
+The output is a normalized image for the n input images. This operation is commonly used as a precursor step for flat removal."""
+
+    @staticmethod
+    def wizard_description():
+        return {
+            'name': Normalization.name(),
+            'description': Normalization.description(),
+            'category': 'image',
+            'inputs': {
+                'input_files': {
+                    'name': 'Input Files',
+                    'description': 'The input files to operate on',
+                    'type': 'file',
+                    'minimum': 1,
+                    'maximum': 999
+                }
+            }
+        }
+    
+    def operate(self):
+
+        input = self.input_data.get('input_files', [])
+
+        log.info(f'Executing normalization operation on {len(input)} file(s) {input}')
+
+        image_data_list = self.get_fits_npdata(input, percent=0.4, cur_percent=0.0)
+        log.info(f'image data list: {image_data_list}')
+        output_files = []
+        for i, image in enumerate(image_data_list):
+            median = np.median(image)
+            normalized_image = image / median
+            fits_file = create_fits(self.cache_key, normalized_image)
+            log.info(f'fits_file: {fits_file}')
+            large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, fits_file)
+            output_file = save_fits_and_thumbnails(self.cache_key, fits_file, large_jpg_path, small_jpg_path, index=i)
+            output_files.append(output_file)
+            log.info(f'x: {output_files}')
+            
+        output =  {'output_files': output_files}
+
+        self.set_percent_completion(1.0)
+        self.set_output(output)
+        log.info(f'Normalization output: {self.get_output()}')

--- a/datalab/datalab_session/s3_utils.py
+++ b/datalab/datalab_session/s3_utils.py
@@ -152,7 +152,7 @@ def save_fits_and_thumbnails(cache_key, fits_path, large_jpg_path, thumbnail_jpg
         'fits_url': fits_url,
         'large_url': large_jpg_url,
         'thumbnail_url': thumbnail_jpg_url,
-        'basename': f'{cache_key}',
+        'basename': f'{bucket_key}',
         'source': 'datalab'}
     )
     


### PR DESCRIPTION
## FEATURE: Normalization operation

**Background:**
Datalab needs more operations. This operation normalizes images

**Implementation:**
Created the operation : )

Corrected one little issue that was causing only one image to show up. In `s3_utils` we changed `'basename': f'{cache_key}'` to `'basename': f'{bucket_key}'`

<img width="1705" alt="Screenshot 2024-09-11 at 11 48 53 AM" src="https://github.com/user-attachments/assets/e70cb4ec-f326-4a67-8fa7-cae010db58c6">
