### PR TITLE
Fix for the getting max dimensions calc

### DIFF
--- a/datalab/datalab_session/utils/file_utils.py
+++ b/datalab/datalab_session/utils/file_utils.py
@@ -69,7 +69,12 @@ def create_jpgs(cache_key, fits_paths: str, color=False, zmin=None, zmax=None) -
     large_jpg_path      = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-large.jpg').name
     thumbnail_jpg_path  = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-small.jpg').name
 
-    max_height, max_width = max(get_fits_dimensions(path) for path in fits_paths)
+    max_height = 0
+    max_width = 0
+    for path in fits_paths:
+      dimensions = get_fits_dimensions(path)
+      max_height = max(max_height, dimensions[0])
+      max_width = max(max_width, dimensions[1])
 
     fits_to_jpg(fits_paths, large_jpg_path, width=max_width, height=max_height, color=color, zmin=zmin, zmax=zmax)
     fits_to_jpg(fits_paths, thumbnail_jpg_path, color=color, zmin=zmin, zmax=zmax)


### PR DESCRIPTION
`get_fits_dimensions` returns a tuple of (height, width) I think, and the `for path in fits_path` part would create a list of tuples, i.e. [(height, width), (height2, width2)]. The max in that case would return the single tuple with the largest height, not the max of height and width, so I'm not sure if that is what we wanted. I.e. max([(1, 3), (4, 2)]) returns (4, 2), not (4, 3)...

The other problem I was having was just related to the RGB images which have 3 dimensions instead of 2, which this also will fix breaking on, but it sounds like we want to just block those anyway so this wouldn't be necessary then.