### PR TITLE
Properly Remove TempFiles

### DIFF
--- a/datalab/datalab_session/analysis/get_tif.py
+++ b/datalab/datalab_session/analysis/get_tif.py
@@ -19,7 +19,7 @@ def get_tif(input: dict):
   else:
     # If tif file doesn't exist, generate a new tif file
     fits_path = get_fits(basename)
-    tif_path = create_tif(basename, fits_path)
-    tif_url = add_file_to_bucket(file_key, tif_path)
+    with create_tif(basename, fits_path) as tif_path:
+      tif_url = add_file_to_bucket(file_key, tif_path)
 
   return {"tif_url": tif_url}

--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -3,6 +3,7 @@ from astropy.wcs import WCS
 from astropy.wcs import WcsError
 from astropy import coordinates
 
+from datalab.datalab_session.exceptions import ClientAlertException
 from datalab.datalab_session.utils.file_utils import scale_points, get_hdu
 from datalab.datalab_session.utils.s3_utils import get_fits
 
@@ -22,7 +23,10 @@ def line_profile(input: dict):
   """
   fits_path = get_fits(input['basename'], input['source'])
 
-  sci_hdu = get_hdu(fits_path, 'SCI')
+  try:
+    sci_hdu = get_hdu(fits_path, 'SCI')
+  except TypeError as e:
+    raise ClientAlertException(f'Error: {e}')
 
   x_points, y_points = scale_points(input["height"], input["width"], sci_hdu.data.shape[0], sci_hdu.data.shape[1], x_points=[input["x1"], input["x2"]], y_points=[input["y1"], input["y2"]])
 

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -133,19 +133,18 @@ class RGB_Stack(BaseDataOperation):
 
         aligned_images = self._align_images(fits_files)
 
-        large_jpg_path, small_jpg_path = create_jpgs(self.cache_key, aligned_images, color=True, zmin=zmin_list, zmax=zmax_list)
-
-        stacked_ndarray = self._create_3d_array(input_handlers)
-        
-        rgb_comment = f'Datalab RGB Stack on files {", ".join(input["basename"] for input in rgb_inputs)}'
-        output = FITSOutputHandler(
-            self.cache_key, 
-            stacked_ndarray, 
-            rgb_comment
-        ).create_and_save_data_products(
-            large_jpg_path=large_jpg_path, 
-            small_jpg_path=small_jpg_path
-        )
+        with create_jpgs(self.cache_key, aligned_images, color=True, zmin=zmin_list, zmax=zmax_list) as (large_jpg_path, small_jpg_path):
+            stacked_ndarray = self._create_3d_array(input_handlers)
+            
+            rgb_comment = f'Datalab RGB Stack on files {", ".join(input["basename"] for input in rgb_inputs)}'
+            output = FITSOutputHandler(
+                self.cache_key, 
+                stacked_ndarray, 
+                rgb_comment
+            ).create_and_save_data_products(
+                large_jpg_path=large_jpg_path, 
+                small_jpg_path=small_jpg_path
+            )
 
         log.info(f'RGB Stack output: {output}')
         self.set_output(output)

--- a/datalab/datalab_session/tests/test_operations.py
+++ b/datalab/datalab_session/tests/test_operations.py
@@ -177,9 +177,9 @@ class TestMedianOperation(FileExtendedTestCase):
         # return the test fits paths in order of the input_files instead of aws fetch
         mock_get_fits.side_effect = [self.test_fits_1_path, self.test_fits_2_path]
         # save temp output to a known path so we can test it
-        mock_named_tempfile.return_value.name = self.temp_median_path
+        mock_named_tempfile.return_value.__enter__.return_value.name = self.temp_median_path
         # avoids overwriting our output
-        mock_create_jpgs.return_value = ('test_path', 'test_path')
+        mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
         mock_save_fits_and_thumbnails.return_value = self.temp_median_path
 
@@ -230,9 +230,9 @@ class TestRGBStackOperation(FileExtendedTestCase):
         # return the test fits paths in order of the input_files instead of aws fetch
         mock_get_fits.side_effect = [self.test_red_path, self.test_green_path, self.test_blue_path]
         # save temp output to a known path so we can test
-        mock_named_tempfile.return_value.name = self.temp_rgb_path
+        mock_named_tempfile.return_value.__enter__.return_value.name = self.temp_rgb_path
         # avoids overwriting our output
-        mock_create_jpgs.return_value = ('test_path', 'test_path')
+        mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
         mock_save_fits_and_thumbnails.return_value = self.temp_rgb_path
 
@@ -300,9 +300,9 @@ class TestStackOperation(FileExtendedTestCase):
         mock_get_fits.side_effect = [self.test_fits_1_path, self.test_fits_2_path,
                                      self.temp_fits_1_negative_path, self.temp_fits_2_negative_path]
         # save temp output to a known path so we can test it
-        mock_named_tempfile.return_value.name = self.temp_stacked_path
+        mock_named_tempfile.return_value.__enter__.return_value.name = self.temp_stacked_path
         # avoids overwriting our output
-        mock_create_jpgs.return_value = ('test_path', 'test_path')
+        mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
         mock_save_fits_and_thumbnails.return_value = self.temp_stacked_path
 

--- a/datalab/datalab_session/tests/test_utils.py
+++ b/datalab/datalab_session/tests/test_utils.py
@@ -17,37 +17,33 @@ class FileUtilsTestClass(FileExtendedTestCase):
 
   def test_create_fits(self):
     test_2d_ndarray = np.zeros((10, 10))
-    path = create_fits('create_fits_test', test_2d_ndarray)
+    with create_fits('create_fits_test', test_2d_ndarray) as path:
+      # test the file was written out to a path
+      self.assertIsInstance(path, str)
+      self.assertIsFile(path)
+      
+      # test the file has the right data
+      hdu = fits.open(path)
+      self.assertEqual(hdu[0].header['KEY'], 'create_fits_test')
+      self.assertEqual(hdu[1].data.tolist(), test_2d_ndarray.tolist())
 
-    # test the file was written out to a path
-    self.assertIsInstance(path, str)
-    self.assertIsFile(path)
-    
-    # test the file has the right data
-    hdu = fits.open(path)
-    self.assertEqual(hdu[0].header['KEY'], 'create_fits_test')
-    self.assertEqual(hdu[1].data.tolist(), test_2d_ndarray.tolist())
-  
   def test_create_tif(self):
     fits_path = self.test_fits_path
-    tif_path = create_tif('create_tif_test', fits_path)
+    with create_tif('create_tif_test', fits_path) as tif_path:
+      # test the file was written out to a path
+      self.assertIsInstance(tif_path, str)
+      self.assertIsFile(tif_path)
+      self.assertFilesEqual(tif_path, self.test_tif_path)
 
-    # test the file was written out to a path
-    self.assertIsInstance(tif_path, str)
-    self.assertIsFile(tif_path)
-
-    self.assertFilesEqual(tif_path, self.test_tif_path)
-  
   def test_create_jpgs(self):
     fits_path = self.test_fits_path
-    jpg_paths = create_jpgs('create_jpgs_test', fits_path)
-
-    # test the files were written out to a path
-    self.assertEqual(len(jpg_paths), 2)
-    self.assertIsFile(jpg_paths[0])
-    self.assertIsFile(jpg_paths[1])
-    self.assertFilesEqual(jpg_paths[0], self.test_large_jpg_path)
-    self.assertFilesEqual(jpg_paths[1], self.test_small_jpg_path)
+    with create_jpgs('create_jpgs_test', fits_path) as jpg_paths:
+      # test the files were written out to a path
+      self.assertEqual(len(jpg_paths), 2)
+      self.assertIsFile(jpg_paths[0])
+      self.assertIsFile(jpg_paths[1])
+      self.assertFilesEqual(jpg_paths[0], self.test_large_jpg_path)
+      self.assertFilesEqual(jpg_paths[1], self.test_small_jpg_path)
   
   def test_stack_arrays(self):
     test_array_1 = np.zeros((10, 20))

--- a/datalab/datalab_session/utils/file_utils.py
+++ b/datalab/datalab_session/utils/file_utils.py
@@ -95,8 +95,11 @@ def create_jpgs(cache_key, fits_paths: str, color=False, zmin=None, zmax=None) -
     try:
       yield large_jpg_path, thumbnail_jpg_path
     finally:
-      os.remove(large_jpg_path)
-      os.remove(thumbnail_jpg_path)
+      try:
+        os.remove(large_jpg_path)
+        os.remove(thumbnail_jpg_path)
+      except FileNotFoundError:
+        pass
 
 def crop_arrays(array_list: list):
   """


### PR DESCRIPTION
Fixes #53 

Adds the context manager decorator to the `create_fits`, `create_tif`, and `create_jpgs` functions. 
This way I can return the file paths to wherever called the function and when its done clean them up.

Also made sure to specify the TEMP_FITS_DIR since there is a cronjob Matt wrote to clean that one, the default was just /tmp. Even though the files are deleted properly now this is just to be extra safe.

Other changes
- Added an error handler to the line profile for a future debugging
- deleted an unused function

Example of the context manger properly cleaning the output files out after they're uploaded to s3, inputs remain in the tmp since they're cached to be used in future operations. (cleaned out in an hour)

https://github.com/user-attachments/assets/d5c2fa5c-aa72-4868-9add-5dcf072e2b6e


