### PR TITLE
get-scaled-jpg endpoint

### DIFF
--- a/datalab/datalab_session/analysis/get_jpg.py
+++ b/datalab/datalab_session/analysis/get_jpg.py
@@ -1,0 +1,30 @@
+import base64
+from datalab.datalab_session.utils.file_utils import create_jpgs
+from datalab.datalab_session.utils.s3_utils import get_fits
+
+def get_jpg(input: dict):
+  """
+    Generates a new jpg file and returns the image
+    input: dict
+      basename: str
+      zmin: int
+      zmax: int
+  """
+
+  basename = input["basename"]
+  zmin = input["zmin"]
+  zmax = input["zmax"]
+
+  fits_path = get_fits(basename)
+
+  with create_jpgs(basename, fits_path, zmin=zmin, zmax=zmax) as (large_jpg_path, small_jpg_path):
+    print('Created scaled jpg with zmin:', zmin, 'zmax:', zmax)
+    with open(large_jpg_path, "rb") as img_file:
+      img_data = img_file.read()
+  
+  # Encode image in Base64
+  img_base64 = base64.b64encode(img_data).decode("utf-8")
+
+  print("Returning image")
+
+  return {"jpg_base64": img_base64}

--- a/datalab/datalab_session/views.py
+++ b/datalab/datalab_session/views.py
@@ -8,9 +8,12 @@ from datalab.datalab_session.data_operations.utils import available_operations
 from datalab.datalab_session.analysis.line_profile import line_profile
 from datalab.datalab_session.analysis.source_catalog import source_catalog
 from datalab.datalab_session.analysis.get_tif import get_tif
+from datalab.datalab_session.analysis.get_jpg import get_jpg
 from datalab.datalab_session.analysis.raw_data import raw_data
 from datalab.datalab_session.exceptions import ClientAlertException
 
+log = logging.getLogger()
+log.setLevel(logging.INFO)
 
 class OperationOptionsApiView(RetrieveAPIView):
     """ View to retrieve the set of operations available, for the UI to use """
@@ -24,37 +27,31 @@ class OperationOptionsApiView(RetrieveAPIView):
         return Response(operation_details)
 
 class AnalysisView(RetrieveAPIView):
-    """ 
-        View to handle analysis actions and return the results
-        To add a new analysis action, add a case to the switch statement and create a new file in the analysis directory
-    """
+    """ View to handle analysis actions and return the results. """
+
+    ACTIONS = {
+        "line-profile": line_profile,
+        "source-catalog": source_catalog,
+        "get-tif": get_tif,
+        "get-jpg": get_jpg,
+        "raw-data": raw_data,
+    }
+
     def post(self, request, action):
-        log = logging.getLogger()
-        log.setLevel(logging.INFO)
+        log.info(f"Received analysis action request: {action}")
 
         try:
-            # TODO replace switch case with an AnalysisAction class
-            # AnalysisAction Class Definition
-            # class AnalysisAction:
-            #     def __init__(self, action):
-            #     def run(self, input):
-            #     def name(self):
-            input = request.data
+            input_data = request.data
+            action_function = self.ACTIONS.get(action)
 
-            match action:
-                case 'line-profile':
-                    output = line_profile(input)
-                case 'source-catalog':
-                    output = source_catalog(input)
-                case 'get-tif':
-                    output = get_tif(input)
-                case 'raw-data':
-                    output = raw_data(input)
-                case _:
-                    raise Exception(f'Analysis action {action} not found')
+            if not action_function:
+                log.warning(f"Invalid action: {action}")
+                return Response({"error": f"Analysis action '{action}' not found"}, status=400)
+
+            output = action_function(input_data)
 
             return Response(output)
-        
+
         except ClientAlertException as error:
             log.error(f"Error running analysis action {action}: {error}")
             return Response({"error": f"Image doesn't support {action}"}, status=400)


### PR DESCRIPTION
Adds a get-jpg endpoint to the analysis view that accepts a file name, and scaling parameters, generates a jpg with the scaling and returns the image as a base64 encoded string.

Refactored the view to use function mapping versus the switch case