### PR TITLE
Update/rgb stack create tif

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,13 @@
+name: "Continuous Deployment"
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  cd:
+    uses: LCOGT/reusable-workflows/.github/workflows/continuous-deployment.yaml@main
+    secrets: inherit

--- a/datalab/datalab_session/analysis/get_tif.py
+++ b/datalab/datalab_session/analysis/get_tif.py
@@ -1,4 +1,4 @@
-from datalab.datalab_session.utils.file_utils import create_tif
+from datalab.datalab_session.utils.file_utils import create_tif, temp_file_manager
 from datalab.datalab_session.utils.s3_utils import key_exists, add_file_to_bucket, get_s3_url, get_fits
 
 def get_tif(input: dict):
@@ -19,7 +19,8 @@ def get_tif(input: dict):
   else:
     # If tif file doesn't exist, generate a new tif file
     fits_path = get_fits(basename)
-    with create_tif(basename, fits_path) as tif_path:
+    with temp_file_manager(f'{basename}.tif') as tif_path:
+      create_tif(fits_path, tif_path)
       tif_url = add_file_to_bucket(file_key, tif_path)
-
+  
   return {"tif_url": tif_url}

--- a/datalab/datalab_session/analysis/get_tif.py
+++ b/datalab/datalab_session/analysis/get_tif.py
@@ -22,5 +22,5 @@ def get_tif(input: dict):
     with temp_file_manager(f'{basename}.tif') as tif_path:
       create_tif(fits_path, tif_path)
       tif_url = add_file_to_bucket(file_key, tif_path)
-  
+
   return {"tif_url": tif_url}

--- a/datalab/datalab_session/data_operations/fits_output_handler.py
+++ b/datalab/datalab_session/data_operations/fits_output_handler.py
@@ -4,8 +4,8 @@ import numpy as np
 from astropy.io import fits
 
 from datalab import settings
-from datalab.datalab_session.utils.file_utils import create_jpgs
-from datalab.datalab_session.utils.s3_utils import save_fits_and_thumbnails
+from datalab.datalab_session.utils.file_utils import create_jpgs, temp_file_manager
+from datalab.datalab_session.utils.s3_utils import save_files_to_s3
 
 
 class FITSOutputHandler():
@@ -42,26 +42,36 @@ class FITSOutputHandler():
     """Add a comment to the FITS file."""
     self.primary_hdu.header.add_comment(comment)
   
-  def create_and_save_data_products(self, index: int=None, large_jpg_path: str=None, small_jpg_path: str=None):
-    """Create the FITS file and save it to S3.
-
-    This function can be called when you're done with the operation and would like to save the FITS file and jpgs in S3.
-    It returns a datalab output dictionary that is formatted to be readable by the frontend.
+  def create_and_save_data_products(self, index: int=None, large_jpg_path: str=None, small_jpg_path: str=None, tif_path: str=None):
+    """
+    When you're done with the operation and would like to save the FITS file and jpgs in S3. JPGs are required, any other file is optional.
     
     Args:
-      index (int): Optionally add an index to the FITS file name. Appended to cache_key for multiple outputs.
-      large_jpg (str): Optionally add a path to a large jpg to save, will not create a new jpg.
-      small_jpg (str): Optionally add a path to a small jpg to save, will not create a new jpg.
+      index (int): Adds an index to the FITS file name for multiple outputs
+      large_jpg (str): existing jpg, used in RGB stack
+      small_jpg (str): existing jpg, used in RGB stack
+      tif_path (str): optional tif file
+    Returns:
+      Datalab output dictionary that is formatted to be readable by the frontend
     """
+    file_paths = {}
     hdu_list = fits.HDUList([self.primary_hdu, self.image_hdu])
-  
+
     with tempfile.NamedTemporaryFile(suffix=f'{self.datalab_id}.fits', dir=settings.TEMP_FITS_DIR) as fits_output_file:
+      # Create the output FITS file
       fits_output_path = fits_output_file.name
       hdu_list.writeto(fits_output_path, overwrite=True)
 
-      # allow for operations to pregenerate the jpgs, ex. RGB stacking
-      if not large_jpg_path or not small_jpg_path:
-        with create_jpgs(self.datalab_id, fits_output_path) as (large_jpg_path, small_jpg_path):
-          return save_fits_and_thumbnails(self.datalab_id, fits_output_path, large_jpg_path, small_jpg_path, index)
-      else:
-        return save_fits_and_thumbnails(self.datalab_id, fits_output_path, large_jpg_path, small_jpg_path, index)
+      # Create jpgs if not provided
+      with temp_file_manager(f"{self.datalab_id}-large.jpg", f"{self.datalab_id}-small.jpg", dir=settings.TEMP_FITS_DIR) as (gen_large_jpg, gen_small_jpg):
+        if not large_jpg_path or not small_jpg_path:
+          create_jpgs(fits_output_path, gen_large_jpg, gen_small_jpg)
+
+        if tif_path:
+          file_paths['tif_path'] = tif_path
+        
+        file_paths['large_jpg_path'] = large_jpg_path or gen_large_jpg
+        file_paths['small_jpg_path'] = small_jpg_path or gen_small_jpg
+        file_paths['fits_path'] = fits_output_path
+
+        return save_files_to_s3(self.datalab_id, index, **file_paths)

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -9,7 +9,7 @@ from datalab.datalab_session.data_operations.input_data_handler import InputData
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.data_operations.fits_output_handler import FITSOutputHandler
 from datalab.datalab_session.exceptions import ClientAlertException
-from datalab.datalab_session.utils.file_utils import crop_arrays, create_jpgs
+from datalab.datalab_session.utils.file_utils import crop_arrays, create_jpgs, create_tif, temp_file_manager
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -133,17 +133,25 @@ class RGB_Stack(BaseDataOperation):
         aligned_images = self._align_images(fits_files)
         self.set_operation_progress(self.PROGRESS_STEPS['ALIGNMENT'])
 
-        with create_jpgs(self.cache_key, aligned_images, color=True, zmin=zmin_list, zmax=zmax_list) as (large_jpg_path, small_jpg_path):
-            stacked_ndarray = self._create_3d_array(input_handlers)
+        with temp_file_manager(
+            f"{self.cache_key}.tif", f"{self.cache_key}-large.jpg", f"{self.cache_key}-small.jpg",
+            dir=settings.TEMP_FITS_DIR
+        ) as (tif_path, large_jpg_path, small_jpg_path):
+        
+            create_tif(aligned_images, tif_path, color=True, zmin=zmin_list, zmax=zmax_list)
+            create_jpgs(aligned_images, large_jpg_path, small_jpg_path, color=True, zmin=zmin_list, zmax=zmax_list)
             
+            stacked_ndarray = self._create_3d_array(input_handlers)
             rgb_comment = f'Datalab RGB Stack on files {", ".join(input["basename"] for input in rgb_inputs)}'
+
             output = FITSOutputHandler(
                 self.cache_key, 
                 stacked_ndarray, 
                 rgb_comment
             ).create_and_save_data_products(
                 large_jpg_path=large_jpg_path, 
-                small_jpg_path=small_jpg_path
+                small_jpg_path=small_jpg_path,
+                tif_path=tif_path
             )
 
         log.info(f'RGB Stack output: {output}')

--- a/datalab/datalab_session/tests/test_operations.py
+++ b/datalab/datalab_session/tests/test_operations.py
@@ -172,7 +172,7 @@ class TestMedianOperation(FileExtendedTestCase):
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_files_to_s3')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
-    def test_operate(self, mock_create_jpgs, mock_save_fits_and_thumbnails, mock_get_fits, mock_named_tempfile):
+    def test_operate(self, mock_create_jpgs, mock_save_files_to_s3, mock_get_fits, mock_named_tempfile):
 
         # return the test fits paths in order of the input_files instead of aws fetch
         mock_get_fits.side_effect = [self.test_fits_1_path, self.test_fits_2_path]
@@ -181,7 +181,7 @@ class TestMedianOperation(FileExtendedTestCase):
         # avoids overwriting our output
         mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
-        mock_save_fits_and_thumbnails.return_value = self.temp_median_path
+        mock_save_files_to_s3.return_value = self.temp_median_path
 
         input_data = {
             'input_files': [
@@ -225,19 +225,15 @@ class TestRGBStackOperation(FileExtendedTestCase):
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.tempfile.NamedTemporaryFile')
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
-    def test_operate(self, mock_get_fits, mock_temp_file_manager, mock_create_jpgs, mock_save_fits_and_thumbnails):
+    def test_operate(self, mock_get_fits, mock_named_tempfile, mock_create_jpgs, mock_save_files_to_s3):
         # return the test fits paths in order of the input_files instead of aws fetch
         mock_get_fits.side_effect = [self.test_red_path, self.test_green_path, self.test_blue_path]
-        # Mock temp_file_manager to return to temp path for testing
-        mock_temp_file_manager.return_value.__enter__.return_value = [
-            self.temp_rgb_path,  # TIFF file path
-            f'{test_path}large_test.jpg',
-            f'{test_path}small_test.jpg'
-        ]
-        # Skip creating jpgs, tiffs, etc.
-        mock_create_jpgs.return_value = ('test_path', 'test_path')
+        # save temp output to a known path so we can test
+        mock_named_tempfile.return_value.__enter__.return_value.name = self.temp_rgb_path
+        # avoids overwriting our output
+        mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
-        mock_save_fits_and_thumbnails.return_value = self.temp_rgb_path
+        mock_save_files_to_s3.return_value = self.temp_rgb_path
 
         input_data = {
             'red_input': [{'basename': 'red_fits', 'source': 'local', 'zmin': 0, 'zmax': 255}],
@@ -251,12 +247,6 @@ class TestRGBStackOperation(FileExtendedTestCase):
 
         self.assertEqual(rgb.get_operation_progress(), 1.0)
         self.assertTrue(os.path.exists(output[0]))
-        # check first 100 bytes of output file
-        with open(output[0], "rb") as f:
-            print("\n Output FITS file content preview: \n\n", f.read(100), '\n\n')
-        # check first 100 bytes of test file
-        with open(self.test_rgb_path, "rb") as f:
-            print("Test FITS file content preview: \n\n", f.read(100), '\n\n')
         self.assertFilesEqual(self.test_rgb_path, output[0])
 
 
@@ -277,7 +267,7 @@ class TestStackOperation(FileExtendedTestCase):
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_files_to_s3')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
-    def test_operate(self, mock_create_jpgs, mock_save_fits_and_thumbnails, mock_get_fits, mock_named_tempfile):
+    def test_operate(self, mock_create_jpgs, mock_save_files_to_s3, mock_get_fits, mock_named_tempfile):
 
         # Create a negative images using numpy
         negative_image_hdul = fits.open(self.test_fits_1_path)
@@ -313,7 +303,7 @@ class TestStackOperation(FileExtendedTestCase):
         # avoids overwriting our output
         mock_create_jpgs.return_value.__enter__.return_value = ('test_path', 'test_path')
         # don't save to s3
-        mock_save_fits_and_thumbnails.return_value = self.temp_stacked_path
+        mock_save_files_to_s3.return_value = self.temp_stacked_path
 
         input_data = {
             # input_data satisfies the Stack operation argument check, but the data comes from the mock_get_fits (above)

--- a/datalab/datalab_session/tests/test_operations.py
+++ b/datalab/datalab_session/tests/test_operations.py
@@ -170,7 +170,7 @@ class TestMedianOperation(FileExtendedTestCase):
 
     @mock.patch('datalab.datalab_session.utils.file_utils.tempfile.NamedTemporaryFile')
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
-    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_fits_and_thumbnails')
+    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_files_to_s3')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
     def test_operate(self, mock_create_jpgs, mock_save_fits_and_thumbnails, mock_get_fits, mock_named_tempfile):
 
@@ -221,9 +221,9 @@ class TestRGBStackOperation(FileExtendedTestCase):
         self.clean_test_dir()
         return super().tearDown()
     
-    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_fits_and_thumbnails')
+    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_files_to_s3')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
-    @mock.patch('datalab.datalab_session.utils.file_utils.tempfile.NamedTemporaryFile')
+    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.tempfile.NamedTemporaryFile')
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
     def test_operate(self, mock_get_fits, mock_named_tempfile, mock_create_jpgs, mock_save_fits_and_thumbnails):
 
@@ -266,7 +266,7 @@ class TestStackOperation(FileExtendedTestCase):
 
     @mock.patch('datalab.datalab_session.utils.file_utils.tempfile.NamedTemporaryFile')
     @mock.patch('datalab.datalab_session.data_operations.input_data_handler.get_fits')
-    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_fits_and_thumbnails')
+    @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.save_files_to_s3')
     @mock.patch('datalab.datalab_session.data_operations.fits_output_handler.create_jpgs')
     def test_operate(self, mock_create_jpgs, mock_save_fits_and_thumbnails, mock_get_fits, mock_named_tempfile):
 

--- a/datalab/datalab_session/tests/test_utils.py
+++ b/datalab/datalab_session/tests/test_utils.py
@@ -29,21 +29,20 @@ class FileUtilsTestClass(FileExtendedTestCase):
 
   def test_create_tif(self):
     fits_path = self.test_fits_path
-    with create_tif('create_tif_test', fits_path) as tif_path:
-      # test the file was written out to a path
+    with temp_file_manager('test.tif') as tif_path:
+      create_tif(fits_path, tif_path)
       self.assertIsInstance(tif_path, str)
       self.assertIsFile(tif_path)
       self.assertFilesEqual(tif_path, self.test_tif_path)
 
   def test_create_jpgs(self):
     fits_path = self.test_fits_path
-    with create_jpgs('create_jpgs_test', fits_path) as jpg_paths:
-      # test the files were written out to a path
-      self.assertEqual(len(jpg_paths), 2)
-      self.assertIsFile(jpg_paths[0])
-      self.assertIsFile(jpg_paths[1])
-      self.assertFilesEqual(jpg_paths[0], self.test_large_jpg_path)
-      self.assertFilesEqual(jpg_paths[1], self.test_small_jpg_path)
+    with temp_file_manager('large.jpg', 'small.jpg') as (large_jpg, small_jpg):
+      create_jpgs(fits_path, large_jpg, small_jpg)
+      self.assertIsFile(large_jpg)
+      self.assertIsFile(small_jpg)
+      self.assertFilesEqual(large_jpg, self.test_large_jpg_path)
+      self.assertFilesEqual(small_jpg, self.test_small_jpg_path)
   
   def test_stack_arrays(self):
     test_array_1 = np.zeros((10, 20))

--- a/datalab/datalab_session/utils/file_utils.py
+++ b/datalab/datalab_session/utils/file_utils.py
@@ -2,16 +2,19 @@ import tempfile
 import logging
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
 from astropy.io import fits
 import numpy as np
-from fits2image.conversions import fits_to_jpg, fits_to_tif
+from fits2image.conversions import fits_to_jpg, fits_to_img
 
 from datalab import settings
 from datalab.datalab_session.exceptions import ClientAlertException
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
+
+TIFF_EXTENSION = 'TIFF'
 
 def get_hdu(path: str, extension: str = 'SCI') -> list[fits.HDUList]:
   """
@@ -53,58 +56,55 @@ def create_fits(key: str, image_arr: np.ndarray, comment=None) -> str:
     os.remove(fits_path)
 
 @contextmanager
-def create_tif(key: str, fits_path: np.ndarray) -> str:
+def temp_file_manager(*filenames, dir=None):
   """
-    Creates a full sized TIFF file from a FITs
-    Returns the path to the TIFF file
+  Context manager to handle multiple temporary files safely.
+  
+  Usage:
+    with temp_file_manager("file1.tif", "file2.jpg") as paths:
+      print(paths)  # List of full file paths
   """
-  height, width = get_fits_dimensions(fits_path)
-  tif_path = tempfile.NamedTemporaryFile(suffix=f'{key}.tif', dir=settings.TEMP_FITS_DIR).name
-  fits_to_tif(fits_path, tif_path, width=width, height=height)
+  temp_dir = dir or tempfile.gettempdir()
+  file_paths = [tempfile.NamedTemporaryFile(suffix=fname, dir=temp_dir, delete=False).name for fname in filenames]
 
   try:
-    yield tif_path
+    if len(file_paths) == 1:
+      yield file_paths[0]
+    else:
+      yield file_paths
   finally:
-    os.remove(tif_path)
+    for path in file_paths:
+      Path(path).unlink(missing_ok=True)
 
-@contextmanager
-def create_jpgs(cache_key, fits_paths: str, color=False, zmin=None, zmax=None) -> list:
-    """
-    Create jpgs from fits files and save them to S3
+def create_jpgs(fits_paths: str, large_jpg_path, thumbnail_jpg_path, color=False, zmin=None, zmax=None) -> list:
+  """
+    Converts FITS images to JPEG images.
     If using the color option fits_paths need to be in order R, G, B
-    percent and cur_percent are used to update the progress of the operation
-    """
+  """
 
-    if not isinstance(fits_paths, list):
-        fits_paths = [fits_paths]
+  if not isinstance(fits_paths, list):
+    fits_paths = [fits_paths]
 
-    # create the jpgs from the fits files
-    large_jpg_path      = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-large.jpg', dir=settings.TEMP_FITS_DIR).name
-    thumbnail_jpg_path  = tempfile.NamedTemporaryFile(suffix=f'{cache_key}-small.jpg', dir=settings.TEMP_FITS_DIR).name
+  max_height, max_width = max(get_fits_dimensions(fp) for fp in fits_paths)
 
-    max_height = 0
-    max_width = 0
-    for path in fits_paths:
-      dimensions = get_fits_dimensions(path)
-      max_height = max(max_height, dimensions[0])
-      max_width = max(max_width, dimensions[1])
+  fits_to_jpg(fits_paths, large_jpg_path, width=max_width, height=max_height, color=color, zmin=zmin, zmax=zmax)
+  fits_to_jpg(fits_paths, thumbnail_jpg_path, color=color, zmin=zmin, zmax=zmax)
 
-    fits_to_jpg(fits_paths, large_jpg_path, width=max_width, height=max_height, color=color, zmin=zmin, zmax=zmax)
-    fits_to_jpg(fits_paths, thumbnail_jpg_path, color=color, zmin=zmin, zmax=zmax)
+def create_tif(fits_paths: np.ndarray, tif_path, color=False, zmin=None, zmax=None) -> str:
+  """
+    Converts FITS images to a TIFF file.
+    If using the color option fits_paths need to be in order R, G, B
+  """
+  if not isinstance(fits_paths, list):
+    fits_paths = [fits_paths]
 
-    try:
-      yield large_jpg_path, thumbnail_jpg_path
-    finally:
-      try:
-        os.remove(large_jpg_path)
-        os.remove(thumbnail_jpg_path)
-      except FileNotFoundError:
-        pass
+  max_height, max_width = max(get_fits_dimensions(fp) for fp in fits_paths)
+  fits_to_img(fits_paths, tif_path, TIFF_EXTENSION, width=max_width, height=max_height, color=color, zmin=zmin, zmax=zmax)
 
 def crop_arrays(array_list: list):
   """
-  Takes a list of numpy arrays from fits images and stacks them to be a 3d numpy array
-  cropped since fits images can be different sizes
+    Takes a list of numpy arrays from fits images and stacks them to be a 3d numpy array
+    cropped since fits images can be different sizes
   """
   min_x = min(arr.shape[0] for arr in array_list)
   min_y = min(arr.shape[1] for arr in array_list)


### PR DESCRIPTION
RGB operations will now generate TIF files in addition to their jpgs. This will let users download the tif of a colored output.

While implementing it became apparent that the current code didn't support adding filetypes to create or output cleanly, so I spent some time refactoring how we handle temporary files as well handling saving files to s3 since these will be often used in the future.

`get_tif`
- uses new temp_file_manager

`fits_output_handler`
- `create_and_save_data_products` now accepts tif
- now uses temp_file_manager
- calls new save_files_to_s3 with a **kwargs pattern

`rgb_stack`
- uses temp_file_manager
- creates and saves a tif file

`test_operations` & `test_file_utils`
- adjusting tests for code changes

`file_utils`
- new `temp_file_manager` allows creation of multiple temp files and closes
- refactored temp file management responsibility out of create_jpg and create_tif

`s3_utils`
- refactored to not rely on parameters since any time we would want to upload a new type of file we'd have to add more and more code
- now will work in a **kwargs pattern to be scalable to any future data products we need to save into the s3 bucket