### PR TITLE
add try except for failed alignments

### DIFF
--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -130,7 +130,12 @@ class RGB_Stack(BaseDataOperation):
 
         fits_files = [handler.fits_file for handler in input_handlers]
 
-        aligned_images = self._align_images(fits_files)
+        try:
+            aligned_images = self._align_images(fits_files)
+        except KeyError:
+            log.info('Could not align images due to missing CAT header')
+            aligned_images = fits_files
+
         self.set_operation_progress(self.PROGRESS_STEPS['ALIGNMENT'])
 
         with create_jpgs(self.cache_key, aligned_images, color=True, zmin=zmin_list, zmax=zmax_list) as (large_jpg_path, small_jpg_path):


### PR DESCRIPTION
Bug: when trying to perform rgb stacks on inputs that are missing CAT headers (like datalab outputs) the align function would fail and error out the operations

Fix: catch the missing CAT in a try except block and accept that the images could not be aligned