### PR TITLE
Fix/image caching get jpg

### DIFF
--- a/datalab/datalab_session/analysis/get_jpg.py
+++ b/datalab/datalab_session/analysis/get_jpg.py
@@ -15,12 +15,11 @@ def get_jpg(input: dict):
   zmin = input["zmin"]
   zmax = input["zmax"]
 
-  fits_path = get_fits(basename)
-
-  with temp_file_manager(f'{basename}_large.jpg', f'{basename}_small.jpg') as (large_jpg, small_jpg):
-    create_jpgs(fits_path, large_jpg, small_jpg, zmin=zmin, zmax=zmax)
-    with open(large_jpg, "rb") as img_file:
-      img_data = img_file.read()
+  with get_fits(basename) as fits_path:
+    with temp_file_manager(f'{basename}_large.jpg', f'{basename}_small.jpg') as (large_jpg, small_jpg):
+      create_jpgs(fits_path, large_jpg, small_jpg, zmin=zmin, zmax=zmax)
+      with open(large_jpg, "rb") as img_file:
+        img_data = img_file.read()
   
   # Encode image in Base64
   img_base64 = base64.b64encode(img_data).decode("utf-8")

--- a/datalab/datalab_session/analysis/get_jpg.py
+++ b/datalab/datalab_session/analysis/get_jpg.py
@@ -1,5 +1,5 @@
 import base64
-from datalab.datalab_session.utils.file_utils import create_jpgs
+from datalab.datalab_session.utils.file_utils import create_jpgs, temp_file_manager
 from datalab.datalab_session.utils.s3_utils import get_fits
 
 def get_jpg(input: dict):
@@ -17,9 +17,9 @@ def get_jpg(input: dict):
 
   fits_path = get_fits(basename)
 
-  with create_jpgs(basename, fits_path, zmin=zmin, zmax=zmax) as (large_jpg_path, small_jpg_path):
-    print('Created scaled jpg with zmin:', zmin, 'zmax:', zmax)
-    with open(large_jpg_path, "rb") as img_file:
+  with temp_file_manager(f'{basename}_large.jpg', f'{basename}_small.jpg') as (large_jpg, small_jpg):
+    create_jpgs(fits_path, large_jpg, small_jpg, zmin=zmin, zmax=zmax)
+    with open(large_jpg, "rb") as img_file:
       img_data = img_file.read()
   
   # Encode image in Base64

--- a/datalab/datalab_session/analysis/get_tif.py
+++ b/datalab/datalab_session/analysis/get_tif.py
@@ -18,9 +18,9 @@ def get_tif(input: dict):
     tif_url = get_s3_url(file_key)
   else:
     # If tif file doesn't exist, generate a new tif file
-    fits_path = get_fits(basename)
-    with temp_file_manager(f'{basename}.tif') as tif_path:
-      create_tif(fits_path, tif_path)
-      tif_url = add_file_to_bucket(file_key, tif_path)
+    with get_fits(basename) as fits_path:
+      with temp_file_manager(f'{basename}.tif') as tif_path:
+        create_tif(fits_path, tif_path)
+        tif_url = add_file_to_bucket(file_key, tif_path)
 
   return {"tif_url": tif_url}

--- a/datalab/datalab_session/analysis/line_profile.py
+++ b/datalab/datalab_session/analysis/line_profile.py
@@ -21,12 +21,11 @@ def line_profile(input: dict):
       y2 (int): The y coordinate of the ending point
     }
   """
-  fits_path = get_fits(input['basename'], input['source'])
-
-  try:
-    sci_hdu = get_hdu(fits_path, 'SCI')
-  except TypeError as e:
-    raise ClientAlertException(f'Error: {e}')
+  with get_fits(input['basename'], input['source']) as fits_path:
+    try:
+      sci_hdu = get_hdu(fits_path, 'SCI')
+    except TypeError as e:
+      raise ClientAlertException(f'Error: {e}')
 
   x_points, y_points = scale_points(input["height"], input["width"], sci_hdu.data.shape[0], sci_hdu.data.shape[1], x_points=[input["x1"], input["x2"]], y_points=[input["y1"], input["y2"]])
 

--- a/datalab/datalab_session/analysis/raw_data.py
+++ b/datalab/datalab_session/analysis/raw_data.py
@@ -9,9 +9,9 @@ from fits2image.scaling import extract_samples, calc_zscale_min_max
 # TODO: This analysis endpoint assumes the image to be of 16 bitdepth. We should make this agnositc to bit depth in the future
 
 def raw_data(input: dict):
-    fits_path = get_fits(input['basename'], input.get('source', 'archive'))
-
-    sci_hdu = get_hdu(fits_path, 'SCI')
+    with get_fits(input['basename'], input.get('source', 'archive')) as fits_path:
+        sci_hdu = get_hdu(fits_path, 'SCI')
+    
     image_data = sci_hdu.data
     
     # Compute the fits2image autoscale params to send with the image

--- a/datalab/datalab_session/analysis/source_catalog.py
+++ b/datalab/datalab_session/analysis/source_catalog.py
@@ -24,10 +24,9 @@ def source_catalog(input: dict):
   """
     Returns a dict representing the source catalog data with x,y coordinates and flux values
   """
-  fits_path = get_fits(input['basename'], input['source'])
-
-  cat_hdu = get_hdu(fits_path, 'CAT')
-  sci_hdu = get_hdu(fits_path, 'SCI')
+  with get_fits(input['basename'], input['source']) as fits_path:
+    cat_hdu = get_hdu(fits_path, 'CAT')
+    sci_hdu = get_hdu(fits_path, 'SCI')
 
   DECIMALS_OF_PRECISION = 6
   MAX_SOURCE_CATALOG_SIZE = min(len(cat_hdu.data["x"]), 1000)

--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -3,11 +3,8 @@ import hashlib
 import json
 
 from django.core.cache import cache
-import numpy as np
 
-from datalab.datalab_session.utils.s3_utils import get_fits
 from datalab.datalab_session.tasks import execute_data_operation
-from datalab.datalab_session.utils.file_utils import get_hdu
 
 CACHE_DURATION = 60 * 60 * 24 * 30  # cache for 30 days
 
@@ -97,19 +94,3 @@ class BaseDataOperation(ABC):
     def set_failed(self, message: str):
         self.set_status('FAILED')
         self.set_message(message)
-
-    def get_fits_npdata(self, input_files: list[dict]) -> list[np.memmap]:
-        image_data_list = []
-
-        # get the fits urls and extract the image data
-        for index, file_info in enumerate(input_files, start=1):
-            basename = file_info.get('basename', 'No basename found')
-            source = file_info.get('source', 'No source found')
-
-            fits_path = get_fits(file_info['basename'], file_info['source'])
-            sci_hdu = get_hdu(fits_path, 'SCI')
-            image_data_list.append(sci_hdu.data)
-
-            self.set_operation_progress(index / len(input_files) * 0.5)
-
-        return image_data_list

--- a/datalab/datalab_session/data_operations/input_data_handler.py
+++ b/datalab/datalab_session/data_operations/input_data_handler.py
@@ -1,3 +1,5 @@
+from contextlib import ExitStack
+
 from astropy.io import fits
 
 from datalab.datalab_session.utils.s3_utils import get_fits
@@ -6,9 +8,6 @@ from datalab.datalab_session.utils.file_utils import get_hdu
 class InputDataHandler():
   """A class to read FITS files and provide access to the data.
 
-  The class inits with a basename and source, and reads the FITS file
-  this data is then stored in the class attributes for easy access.
-
   Attributes:
     basename (str): The basename of the FITS file.
     fits_file (str): The path to the FITS file.
@@ -16,20 +15,22 @@ class InputDataHandler():
   """
 
   def __init__(self, basename: str, source: str = None) -> None:
-    """Inits InputDataHandler with basename and source.
-    
-    Uses the basename to query the archive for the matching FITS file.
-    Also can take a source argument to specify a different source for the FITS file.
-    At the time of writing two common sources are 'datalab' and 'archive'.
-    New sources will need to be added in the get_fits function in s3_utils.py.
+    """
+    Supported sources are 'datalab' and 'archive'
+    New sources will need to be added in get_fits
 
     Args:
-      basename (str): The basename of the FITS file.
-      source (str): Optionally add a source to the FITS file in case it's not the LCO archive.
+      basename (str): The basename query for the FITS file
+      source (str): location of the fits file
     """
     self.basename = basename
-    self.fits_file = get_fits(basename, source)
+    self.source = source
+    self.exit_stack = ExitStack()
+    self.fits_file = self.exit_stack.enter_context(get_fits(basename, source))
     self.sci_data = get_hdu(self.fits_file, 'SCI').data
+  
+  def __del__(self):
+    self.exit_stack.close()
 
   def __str__(self) -> str:
     with fits.open(self.fits_file) as hdul:

--- a/datalab/datalab_session/tests/test_analysis.py
+++ b/datalab/datalab_session/tests/test_analysis.py
@@ -20,7 +20,7 @@ class TestAnalysis(TestCase):
     @mock.patch('datalab.datalab_session.analysis.line_profile.get_fits')
     def test_line_profile(self, mock_get_fits):
 
-        mock_get_fits.return_value = self.analysis_fits_1_path
+        mock_get_fits.return_value.__enter__.return_value = self.analysis_fits_1_path
 
         output = line_profile.line_profile({
             'basename': 'fits_1',
@@ -38,7 +38,7 @@ class TestAnalysis(TestCase):
     @mock.patch('datalab.datalab_session.analysis.source_catalog.get_fits')
     def test_source_catalog(self, mock_get_fits):
 
-        mock_get_fits.return_value = self.analysis_fits_1_path
+        mock_get_fits.return_value.__enter__.return_value = self.analysis_fits_1_path
         
         output = source_catalog.source_catalog({
             'basename': 'fits_1',


### PR DESCRIPTION
As part of a fix to better manage Datalab memory, get_fits is now a context manager and cleans any fits files downloaded.

Before, FITS files were downloaded and stored in a tmp directory cleared every 30 minutes. However, with increased users or larger operations, this temporary directory is filling up before the cleaner can execute its task, resulting in server crashes due to out-of-memory (OOM) issues.

This fix means images are no longer cached, and there are still a few other long term issues to address:

- The available space for Datalab needs to be increased. Currently, it is set to 128 MB, which will cause the server to crash if a large analysis image is loaded. (Analysis might need to be moved into dramatiq as well for reasons below)
- Research and upgrade get_fits to potentially use Redis for caching images. This would involve downloading and caching images to a Redis database and automatically evicting the oldest images when space is low.
- We need to improve logging in ArgoCD to monitor Datalab's space usage. As the number of users grows, the space requirement will also rise since each operation generates temporary products.
- Investigate how to utilize worker-specific temporary directories, so the main thread doesn't handle all temporary files, preventing it from being overwhelmed. By doing this, each worker can be allocated space for the needs of a single operation, instead of relying on the main Django thread to manage space for all operations from all users.

There's a lot of work to be done here. While Datalab will remain stable at low user counts, the likelihood of crashes increases as operations scale. Space required for workers may also have to be dynamic based on app use.