### PR TITLE
increase datalab tmp size to 1Gi

### DIFF
--- a/k8s/base/deploy-server.yaml
+++ b/k8s/base/deploy-server.yaml
@@ -19,11 +19,19 @@ spec:
         fsGroup: 1000
       volumes:
         - name: tmp
-          emptyDir:
-            sizeLimit: 1Gi
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  type: datalab-server-tmp-volume
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                resources:
+                  requests:
+                    storage: 1Gi
         - name: static
           emptyDir:
-            sizeLimit: 1Gi
+            sizeLimit: 128Mi
       initContainers:
         - name: check-db-ready
           image: postgres:14-alpine

--- a/k8s/base/deploy-server.yaml
+++ b/k8s/base/deploy-server.yaml
@@ -20,10 +20,10 @@ spec:
       volumes:
         - name: tmp
           emptyDir:
-            sizeLimit: 128Mi
+            sizeLimit: 1Gi
         - name: static
           emptyDir:
-            sizeLimit: 128Mi
+            sizeLimit: 1Gi
       initContainers:
         - name: check-db-ready
           image: postgres:14-alpine


### PR DESCRIPTION
Increase the size of the main django threads drive to 1Gi from 128Mi