### PR TITLE
up the worker memory from 1Gi to 2Gi

### DIFF
--- a/k8s/base/deploy-worker.yaml
+++ b/k8s/base/deploy-worker.yaml
@@ -28,7 +28,7 @@ spec:
                 accessModes: [ "ReadWriteOnce" ]
                 resources:
                   requests:
-                    storage: 1Gi
+                    storage: 2Gi
       containers:
         - name: default
           image: datalab


### PR DESCRIPTION
Just as it was possible to crash the server with only 1Gi, workers need 2Gi as well for RGB stacks on large images as a temp fix for beta users. Work should be done to develop better ways of reducing memory.