### PR TITLE
Feature/output types

### DIFF
--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -5,6 +5,7 @@ import json
 from django.core.cache import cache
 
 from datalab.datalab_session.tasks import execute_data_operation
+from datalab.datalab_session.utils.format import Format
 
 CACHE_DURATION = 60 * 60 * 24 * 30  # cache for 30 days
 
@@ -21,7 +22,7 @@ class BaseDataOperation(ABC):
             return {}
         input_schema = self.wizard_description().get('inputs', {})
         for key, value in input_data.items():
-            if input_schema.get(key, {}).get('type', '') == 'file' and type(value) is list:
+            if input_schema.get(key, {}).get('type', '') == Format.FITS and type(value) is list:
                 # If there are file type inputs with multiple files, sort them by basename since order doesn't matter
                 value.sort(key=lambda x: x['basename'])
         return input_data

--- a/datalab/datalab_session/data_operations/fits_output_handler.py
+++ b/datalab/datalab_session/data_operations/fits_output_handler.py
@@ -43,7 +43,7 @@ class FITSOutputHandler():
     """Add a comment to the FITS file."""
     self.primary_hdu.header.add_comment(comment)
   
-  def create_and_save_data_products(self, index: int=None, large_jpg_path: str=None, small_jpg_path: str=None, tif_path: str=None):
+  def create_and_save_data_products(self, format, index: int=None, large_jpg_path: str=None, small_jpg_path: str=None, tif_path: str=None):
     """
     When you're done with the operation and would like to save the FITS file and jpgs in S3. JPGs are required, any other file is optional.
     
@@ -75,4 +75,4 @@ class FITSOutputHandler():
         file_paths['small_jpg_path'] = small_jpg_path or gen_small_jpg
         file_paths['fits_path'] = fits_output_path
 
-        return save_files_to_s3(self.datalab_id, file_paths, index)
+        return save_files_to_s3(self.datalab_id, format, file_paths, index)

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -6,6 +6,7 @@ from datalab.datalab_session.data_operations.input_data_handler import InputData
 from datalab.datalab_session.data_operations.fits_output_handler import FITSOutputHandler
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.exceptions import ClientAlertException
+from datalab.datalab_session.utils.format import Format
 from datalab.datalab_session.utils.file_utils import crop_arrays
 
 log = logging.getLogger()
@@ -34,7 +35,7 @@ The output is a median image for the n input images. This operation is commonly 
                 'input_files': {
                     'name': 'Input Files',
                     'description': 'The input files to operate on',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 999
                 }
@@ -60,6 +61,6 @@ The output is a median image for the n input images. This operation is commonly 
 
         self.set_operation_progress(0.80)
 
-        output = FITSOutputHandler(self.cache_key, median, comment).create_and_save_data_products()
+        output = FITSOutputHandler(self.cache_key, median, comment).create_and_save_data_products(Format.FITS)
         log.info(f'Median output: {output}')
         self.set_output(output)

--- a/datalab/datalab_session/data_operations/normalization.py
+++ b/datalab/datalab_session/data_operations/normalization.py
@@ -5,6 +5,7 @@ import numpy as np
 from datalab.datalab_session.data_operations.input_data_handler import InputDataHandler
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.data_operations.fits_output_handler import FITSOutputHandler
+from datalab.datalab_session.utils.format import Format
 
 log = logging.getLogger()
 log.setLevel(logging.INFO)
@@ -32,7 +33,7 @@ The output is a normalized image. This operation is commonly used as a precursor
                 'input_files': {
                     'name': 'Input Files',
                     'description': 'The input files to operate on',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 999
                 }
@@ -51,7 +52,7 @@ The output is a normalized image. This operation is commonly used as a precursor
                 normalized_image = image.sci_data / median
 
                 comment = f'Datalab Normalization on file {input_list[index-1]["basename"]}'
-                output = FITSOutputHandler(f'{self.cache_key}', normalized_image, comment, data_header=image.sci_hdu.header.copy()).create_and_save_data_products(index=index)
+                output = FITSOutputHandler(f'{self.cache_key}', normalized_image, comment, data_header=image.sci_hdu.header.copy()).create_and_save_data_products(Format.FITS, index=index)
                 output_files.append(output)
                 self.set_operation_progress(0.9 * index / len(input_list))
 

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -9,6 +9,7 @@ from datalab.datalab_session.data_operations.input_data_handler import InputData
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.utils.s3_utils import save_files_to_s3
 from datalab.datalab_session.exceptions import ClientAlertException
+from datalab.datalab_session.utils.format import Format
 from datalab.datalab_session.utils.file_utils import create_jpgs, create_tif, temp_file_manager
 
 
@@ -41,7 +42,7 @@ class RGB_Stack(BaseDataOperation):
                 'red_input': {
                     'name': 'Red Filter',
                     'description': 'Three images to stack their RGB values',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 1,
                     'include_custom_scale': True,
@@ -51,7 +52,7 @@ class RGB_Stack(BaseDataOperation):
                 'green_input': {
                     'name': 'Green Filter',
                     'description': 'Three images to stack their RGB values',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 1,
                     'include_custom_scale': True,
@@ -61,7 +62,7 @@ class RGB_Stack(BaseDataOperation):
                 'blue_input': {
                     'name': 'Blue Filter',
                     'description': 'Three images to stack their RGB values',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 1,
                     'include_custom_scale': True,
@@ -144,7 +145,7 @@ class RGB_Stack(BaseDataOperation):
                 'tif_path': tif_path
             }
 
-            output = save_files_to_s3(self.cache_key, file_paths)
+            output = save_files_to_s3(self.cache_key, Format.IMAGE, file_paths)
 
         log.info(f'RGB Stack output: {output}')
         self.set_output(output)

--- a/datalab/datalab_session/data_operations/stacking.py
+++ b/datalab/datalab_session/data_operations/stacking.py
@@ -6,6 +6,7 @@ from datalab.datalab_session.data_operations.input_data_handler import InputData
 from datalab.datalab_session.data_operations.fits_output_handler import FITSOutputHandler
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.exceptions import ClientAlertException
+from datalab.datalab_session.utils.format import Format
 from datalab.datalab_session.utils.file_utils import crop_arrays
 
 log = logging.getLogger()
@@ -34,7 +35,7 @@ The output is a stacked image for the n input images. This operation is commonly
                 'input_files': {
                     'name': 'Input Files',
                     'description': 'The input files to operate on',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 999
                 }
@@ -60,7 +61,7 @@ The output is a stacked image for the n input images. This operation is commonly
         stacked_sum = np.sum(cropped_data, axis=0)
         self.set_operation_progress(0.8)
 
-        output = FITSOutputHandler(self.cache_key, stacked_sum, comment).create_and_save_data_products()
+        output = FITSOutputHandler(self.cache_key, stacked_sum, comment).create_and_save_data_products(Format.FITS)
 
         log.info(f'Stacked output: {output}')
         self.set_output(output)

--- a/datalab/datalab_session/data_operations/subtraction.py
+++ b/datalab/datalab_session/data_operations/subtraction.py
@@ -6,6 +6,7 @@ from datalab.datalab_session.data_operations.input_data_handler import InputData
 from datalab.datalab_session.data_operations.data_operation import BaseDataOperation
 from datalab.datalab_session.data_operations.fits_output_handler import FITSOutputHandler
 from datalab.datalab_session.exceptions import ClientAlertException
+from datalab.datalab_session.utils.format import Format
 from datalab.datalab_session.utils.file_utils import crop_arrays
 
 log = logging.getLogger()
@@ -35,14 +36,14 @@ class Subtraction(BaseDataOperation):
                 'input_files': {
                     'name': 'Input Files',
                     'description': 'The input files to operate on',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 999
                 },
                 'subtraction_file': {
                     'name': 'Subtraction File',
                     'description': 'This file will be subtracted from the input images.',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 1
                 }
@@ -70,7 +71,7 @@ class Subtraction(BaseDataOperation):
                 subtraction_comment = f'Datalab Subtraction of {subtraction_file_input[0]["basename"]} subtracted from {input_files[index-1]["basename"]}'
                 outputs.append(FITSOutputHandler(
                     f'{self.cache_key}', difference_array, subtraction_comment,
-                    data_header=input_image.sci_hdu.header.copy()).create_and_save_data_products(index=index))
+                    data_header=input_image.sci_hdu.header.copy()).create_and_save_data_products(Format.FITS, index=index))
                 self.set_operation_progress(0.9 + index / len(input_files))
 
         log.info(f'Subtraction output: {outputs}')

--- a/datalab/datalab_session/tests/test_operations.py
+++ b/datalab/datalab_session/tests/test_operations.py
@@ -11,6 +11,7 @@ from datalab.datalab_session.exceptions import ClientAlertException
 from datalab.datalab_session.data_operations.median import Median
 from datalab.datalab_session.data_operations.stacking import Stack
 from datalab.datalab_session.tests.test_files.file_extended_test_case import FileExtendedTestCase
+from datalab.datalab_session.utils.format import Format
 
 wizard_description = {
             'name': 'SampleDataOperation',
@@ -20,7 +21,7 @@ wizard_description = {
                 'input_files': {
                     'name': 'Input Files',
                     'description': 'The input files to operate on',
-                    'type': 'file',
+                    'type': Format.FITS,
                     'minimum': 1,
                     'maximum': 999
                 },

--- a/datalab/datalab_session/utils/format.py
+++ b/datalab/datalab_session/utils/format.py
@@ -1,0 +1,7 @@
+class Format():
+  """Class that provides format types used in datalab inputs and outputs"""
+
+  FITS = 'fits' # A properly formatted FITS file with 2D image data and header ex. median output
+  IMAGE = 'image' # Image only with no FITS file associated with it ex. rgb_stack output
+  # TABLE = 'table' # A table of data ex. future astro_source output
+  # JSON = 'json' # Raw JSON data

--- a/datalab/datalab_session/utils/s3_utils.py
+++ b/datalab/datalab_session/utils/s3_utils.py
@@ -147,7 +147,7 @@ def get_fits(basename: str, source: str = 'archive'):
   finally:
     Path(fits_path).unlink(missing_ok=True)
 
-def save_files_to_s3(cache_key, file_paths: dict, index=None):
+def save_files_to_s3(cache_key, format, file_paths: dict, index=None):
   """
   Save multiple files to S3, generating URLs and returning them in a structured output.
   **file_paths args should follow convention of <annotation>_<file_type>_path
@@ -157,7 +157,8 @@ def save_files_to_s3(cache_key, file_paths: dict, index=None):
   bucket_key = f'{cache_key}/{cache_key}-{index}' if index else f'{cache_key}/{cache_key}'
   output = {
     'basename': f'{cache_key}-{index}' if index else cache_key,
-    'source': 'datalab'
+    'source': 'datalab',
+    'type': format
   }
  
   for key, path in file_paths.items():


### PR DESCRIPTION
This PR supports the [frontend PR](https://github.com/LCOGT/datalab-ui/pull/190) that lets us now filter inputs based on file type.

Added a Format class to keep track of supported datalab inputs and outputs. This will let us add new types as they come up in the future.

Changed the 'file' type for input descriptions to 'fits' to represent a working fits file.

RGB stack now has the output of type 'image' so that when you try to perform a median or other operation that requires proper fits files, RGB's output won't show up.

