### PR TITLE
Update to store output as generated for partial output

### DIFF
--- a/datalab/datalab_session/data_operations/data_operation.py
+++ b/datalab/datalab_session/data_operations/data_operation.py
@@ -115,8 +115,6 @@ class BaseDataOperation(ABC):
     def set_output(self, output):
         output_data = {'output_files': output if isinstance(output, list) else [output]}
         cache.set(f'operation_{self.cache_key}_output', output_data, CACHE_DURATION)
-        self.set_operation_progress(1.0)
-        self.set_status('COMPLETED')
 
     def get_output(self) -> dict:
         return cache.get(f'operation_{self.cache_key}_output')

--- a/datalab/datalab_session/data_operations/median.py
+++ b/datalab/datalab_session/data_operations/median.py
@@ -65,3 +65,5 @@ The output is a median image for the n input images. This operation is commonly 
         output = FITSOutputHandler(self.cache_key, median, self.temp, comment).create_and_save_data_products(Format.FITS)
         log.info(f'Median output: {output}')
         self.set_output(output)
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')

--- a/datalab/datalab_session/data_operations/normalization.py
+++ b/datalab/datalab_session/data_operations/normalization.py
@@ -55,7 +55,10 @@ The output is a normalized image. This operation is commonly used as a precursor
                 comment = f'Datalab Normalization on file {input_list[index-1]["basename"]}'
                 output = FITSOutputHandler(f'{self.cache_key}', normalized_image, self.temp, comment, data_header=image.sci_hdu.header.copy()).create_and_save_data_products(Format.FITS, index=index)
                 output_files.append(output)
+                self.set_output(output_files)
                 self.set_operation_progress(0.9 * index / len(input_list))
 
         log.info(f'Normalization output: {output_files}')
         self.set_output(output_files)
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')

--- a/datalab/datalab_session/data_operations/rgb_stack.py
+++ b/datalab/datalab_session/data_operations/rgb_stack.py
@@ -148,3 +148,5 @@ class RGB_Stack(BaseDataOperation):
 
         log.info(f'RGB Stack output: {output}')
         self.set_output(output)
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')

--- a/datalab/datalab_session/data_operations/stacking.py
+++ b/datalab/datalab_session/data_operations/stacking.py
@@ -66,3 +66,5 @@ The output is a stacked image for the n input images. This operation is commonly
 
         log.info(f'Stacked output: {output}')
         self.set_output(output)
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')

--- a/datalab/datalab_session/data_operations/subtraction.py
+++ b/datalab/datalab_session/data_operations/subtraction.py
@@ -73,7 +73,10 @@ class Subtraction(BaseDataOperation):
                 outputs.append(FITSOutputHandler(
                     f'{self.cache_key}', difference_array, self.temp, subtraction_comment,
                     data_header=input_image.sci_hdu.header.copy()).create_and_save_data_products(Format.FITS, index=index))
+                self.set_output(outputs)
                 self.set_operation_progress(0.9 + index / len(input_files))
 
         log.info(f'Subtraction output: {outputs}')
         self.set_output(outputs)
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')

--- a/datalab/datalab_session/tests/test_operations.py
+++ b/datalab/datalab_session/tests/test_operations.py
@@ -59,6 +59,8 @@ class SampleDataOperation(BaseDataOperation):
     
     def operate(self, submitter):
         self.set_output([])
+        self.set_operation_progress(1.0)
+        self.set_status('COMPLETED')
 
 
 class TestDataOperation(FileExtendedTestCase):
@@ -150,6 +152,8 @@ class TestDataOperation(FileExtendedTestCase):
 
     def test_set_get_output(self):
         self.data_operation.set_output([])
+        self.data_operation.set_operation_progress(1.0)
+        self.data_operation.set_status('COMPLETED')
         self.assertEqual(self.data_operation.get_operation_progress(), 1.0)
         self.assertEqual(self.data_operation.get_status(), 'COMPLETED')
         self.assertEqual(self.data_operation.get_output(), {'output_files': []})


### PR DESCRIPTION
Very simple, just decouple setting output from setting status/progress and then set output while its computed for Subtraction and Normalization operations

[datalab_partial_output.webm](https://github.com/user-attachments/assets/a50cb21c-bd65-4fc6-a171-80634ed1c1d3)
