### PR TITLE
wrap period calculation in try except and return 0 if not found

### DIFF
--- a/datalab/datalab_session/analysis/variable_star.py
+++ b/datalab/datalab_session/analysis/variable_star.py
@@ -69,7 +69,11 @@ def variable_star(input: dict, user: User):
       'julian_date': Time(image.get("observation_date")).jd,
     })
   
-  period, fap = calculate_period(light_curve)
+  try:
+    period, fap = calculate_period(light_curve)
+  except Exception as e:
+    log.error(f"Error calculating period: {e}")
+    period, fap = 0, 0
 
   return {
     'target_coords': coords,


### PR DESCRIPTION
Adds a try except catch to the period calculation, astropy's LombScargle periodogram calculation seems to fail under a couple of circumstances
- if there are less than 3 data points
- if theres improperly formatted data

This doesn't address fixing that, but instead has a fallback so that the server doesn't 500 and it still returns the light curve data so the frontend can display.

Future improvements would be better error messaging for clarity, couldn't use the ClientAlertException since that would halt runtime and we couldn't return the light-curve part of the calculation.

Paired with: https://github.com/LCOGT/datalab-ui/pull/236