### PR TITLE
Cache per-frame WCS and aperture geometry for light-curve measurement

### DIFF
--- a/datalab/datalab_session/tests/test_aperture_photometry.py
+++ b/datalab/datalab_session/tests/test_aperture_photometry.py
@@ -316,7 +316,7 @@ class TestAperturePhotometry(unittest.TestCase):
         # lock on. _measure_target must never raise or drift onto a neighbour: it measures at the
         # authoritative WCS position instead of the real source at (30.3, 28.8).
         from datalab.datalab_session.utils.aperture_light_curve import _load_frame_image, _measure_target
-        from datalab.datalab_session.utils.fits_metadata import world_to_pixel
+        from datalab.datalab_session.utils.fits_metadata import frame_geometry, world_to_pixel
 
         frames, _ = build_frame_set()
         header = frames["frame_1.fits"]["header"]
@@ -328,11 +328,9 @@ class TestAperturePhotometry(unittest.TestCase):
         measurement = _measure_target(
             frame=frame,
             image=_load_frame_image(frame.fits_path),
+            geometry=frame_geometry(frame.header, 4.0, 6.0, 9.0),
             target_ra_deg=empty_ra,
             target_dec_deg=empty_dec,
-            aperture_radius=4.0,
-            annulus_inner_radius=6.0,
-            annulus_outer_radius=9.0,
         )
 
         self.assertAlmostEqual(measurement.x, initial_x, delta=1.0e-6)

--- a/datalab/datalab_session/utils/aperture_light_curve.py
+++ b/datalab/datalab_session/utils/aperture_light_curve.py
@@ -19,8 +19,10 @@ from datalab.datalab_session.utils.comparison_stars import (
 )
 from datalab.datalab_session.utils.centroiding import calculate_background_model, centroid
 from datalab.datalab_session.utils.fits_metadata import (
+    FrameGeometry,
     arcsec_to_pixels,
     frame_gain,
+    frame_geometry,
     frame_read_noise,
     optional_float,
     world_to_pixel,
@@ -523,14 +525,16 @@ def _measure_frame_pixels(
         ids of candidates that failed to measure on this frame, and the preview.
     """
     image = _load_frame_image(frame.fits_path)
+    # Build the frame's WCS and pixel-space aperture radii once, then reuse them for the target and
+    # every candidate. These are frame constants, so recomputing them per candidate (as the old
+    # arcsec_to_pixels/world_to_pixel calls did) just re-parsed the header WCS thousands of times.
+    geometry = frame_geometry(frame.header, aperture_radius, annulus_inner_radius, annulus_outer_radius)
     target_measurement = _measure_target(
         frame=frame,
         image=image,
+        geometry=geometry,
         target_ra_deg=target_ra_deg,
         target_dec_deg=target_dec_deg,
-        aperture_radius=aperture_radius,
-        annulus_inner_radius=annulus_inner_radius,
-        annulus_outer_radius=annulus_outer_radius,
     )
     candidate_measurements: dict[str, ComparisonMeasurement] = {}
     failed_candidate_ids: set[str] = set()
@@ -541,10 +545,8 @@ def _measure_frame_pixels(
             candidate_measurements[candidate.candidate_id] = measure_candidate_on_frame(
                 frame=frame,
                 image=image,
+                geometry=geometry,
                 candidate=candidate,
-                aperture_radius=aperture_radius,
-                annulus_inner_radius=annulus_inner_radius,
-                annulus_outer_radius=annulus_outer_radius,
                 error_class=LightCurveError,
             )
         except LightCurveError:
@@ -598,28 +600,27 @@ def _measure_target(
     *,
     frame: FrameContext,
     image: np.ndarray,
+    geometry: FrameGeometry,
     target_ra_deg: float,
     target_dec_deg: float,
-    aperture_radius: float,
-    annulus_inner_radius: float,
-    annulus_outer_radius: float,
 ) -> TargetMeasurement:
     """
         Converts the target RA and Dec to pixel coordinates, centroids the source, and measures
         aperture photometry. image is the frame's pixel data, passed separately from the metadata
-        so the streaming pixel pass controls how long it stays in memory.
+        so the streaming pixel pass controls how long it stays in memory. geometry carries the
+        frame's cached WCS and pixel-space aperture radii.
 
         The target is never allowed to drop a frame: if centroiding fails or the refinement drifts
         too far from the WCS position, it measures at the authoritative WCS position instead.
 
         Returns the target measurement for a single frame.
     """
-    aperture_radius_px = arcsec_to_pixels(frame.header, aperture_radius)
-    annulus_inner_radius_px = arcsec_to_pixels(frame.header, annulus_inner_radius)
-    annulus_outer_radius_px = arcsec_to_pixels(frame.header, annulus_outer_radius)
+    aperture_radius_px = geometry.aperture_radius_px
+    annulus_inner_radius_px = geometry.annulus_inner_radius_px
+    annulus_outer_radius_px = geometry.annulus_outer_radius_px
 
     try:
-        initial_x, initial_y = world_to_pixel(frame.header, target_ra_deg, target_dec_deg)
+        initial_x, initial_y = geometry.world_to_pixel(target_ra_deg, target_dec_deg)
     except Exception as exc:
         raise LightCurveError(f"Target WCS localization failed for {frame.fits_path}.") from exc
     log.info(

--- a/datalab/datalab_session/utils/comparison_stars.py
+++ b/datalab/datalab_session/utils/comparison_stars.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Sequence
 import numpy as np
 
 from datalab.datalab_session.utils.centroiding import centroid
-from datalab.datalab_session.utils.fits_metadata import arcsec_to_pixels, frame_gain, frame_read_noise, world_to_pixel
+from datalab.datalab_session.utils.fits_metadata import FrameGeometry, frame_gain, frame_read_noise
 from datalab.datalab_session.utils.photometry import measure_aperture
 
 
@@ -143,16 +143,16 @@ def measure_candidate_on_frame(
     *,
     frame: Any,
     image: np.ndarray,
+    geometry: FrameGeometry,
     candidate: ComparisonStar,
-    aperture_radius: float,
-    annulus_inner_radius: float,
-    annulus_outer_radius: float,
     error_class: type[Exception] = ValueError,
 ) -> ComparisonMeasurement:
     """
         Measures aperture photometry for one comparison-star candidate on a single FITS frame.
 
         image is the frame's full-resolution pixel data, passed separately from the frame metadata.
+        geometry carries the frame's cached WCS and pixel-space aperture radii, shared across every
+        candidate on the frame.
 
         Converts the candidate's RA/Dec to pixel coordinates via the frame WCS, centroids around
         that position to refine it (correcting small WCS or catalog inaccuracies), then measures
@@ -161,10 +161,10 @@ def measure_candidate_on_frame(
 
         Returns the comparison-star measurement for this frame.
     """
-    aperture_radius_px = arcsec_to_pixels(frame.header, aperture_radius)
-    annulus_inner_radius_px = arcsec_to_pixels(frame.header, annulus_inner_radius)
-    annulus_outer_radius_px = arcsec_to_pixels(frame.header, annulus_outer_radius)
-    x, y = world_to_pixel(frame.header, candidate.ra_deg, candidate.dec_deg)
+    aperture_radius_px = geometry.aperture_radius_px
+    annulus_inner_radius_px = geometry.annulus_inner_radius_px
+    annulus_outer_radius_px = geometry.annulus_outer_radius_px
+    x, y = geometry.world_to_pixel(candidate.ra_deg, candidate.dec_deg)
     centroid_result = centroid(
         image=image,
         x_click=x,

--- a/datalab/datalab_session/utils/fits_metadata.py
+++ b/datalab/datalab_session/utils/fits_metadata.py
@@ -1,4 +1,5 @@
 import math
+from dataclasses import dataclass
 from typing import Any, Mapping
 
 import numpy as np
@@ -64,3 +65,45 @@ def arcsec_to_pixels(header: Mapping[str, Any], angular_radius_arcsec: float) ->
         Convert an angular aperture radius to pixels for one frame, using the frame's plate scale.
     """
     return float(angular_radius_arcsec) / pixel_scale_arcsec(header)
+
+
+@dataclass(frozen=True)
+class FrameGeometry:
+    """
+        Per-frame WCS and pixel-space aperture geometry, built once and reused for the target and
+        every comparison candidate on the frame.
+
+        Constructing a WCS from a header costs on the order of ~10 ms; arcsec_to_pixels and
+        world_to_pixel each built one per call, so measuring a frame's candidates rebuilt it
+        thousands of times. The plate scale and WCS are frame constants, so they are computed once
+        here instead of per candidate.
+    """
+    wcs: WCS
+    aperture_radius_px: float
+    annulus_inner_radius_px: float
+    annulus_outer_radius_px: float
+
+    def world_to_pixel(self, ra_deg: float, dec_deg: float) -> tuple[float, float]:
+        """Pixel coordinates of a sky position using the cached WCS (no header re-parse)."""
+        x, y = self.wcs.world_to_pixel_values(float(ra_deg), float(dec_deg))
+        return float(x), float(y)
+
+
+def frame_geometry(
+    header: Mapping[str, Any],
+    aperture_radius_arcsec: float,
+    annulus_inner_radius_arcsec: float,
+    annulus_outer_radius_arcsec: float,
+) -> FrameGeometry:
+    """
+        Builds the reusable per-frame geometry: one WCS plus the three aperture radii converted to
+        pixels via the frame's plate scale. Matches arcsec_to_pixels/world_to_pixel exactly, just
+        without rebuilding the WCS for every candidate.
+    """
+    pixel_scale = pixel_scale_arcsec(header)
+    return FrameGeometry(
+        wcs=WCS(dict(header)),
+        aperture_radius_px=float(aperture_radius_arcsec) / pixel_scale,
+        annulus_inner_radius_px=float(annulus_inner_radius_arcsec) / pixel_scale,
+        annulus_outer_radius_px=float(annulus_outer_radius_arcsec) / pixel_scale,
+    )


### PR DESCRIPTION
Add FrameGeometry (fits_metadata), built once per frame, holding the cached WCS plus the aperture/annulus radii in pixels, and thread it through _measure_target and measure_candidate_on_frame. WCS builds drop from ~4 per candidate to ~2 per frame.

Testing on the NGC7331 in rp data set on my machine confirmed that the results are identical but run time falls from 72s to 16s.