### PR TITLE
Fix/ap phot diagnostic images

### DIFF
--- a/datalab/datalab_session/tests/test_aperture_photometry.py
+++ b/datalab/datalab_session/tests/test_aperture_photometry.py
@@ -715,6 +715,8 @@ class TestAperturePhotometry(unittest.TestCase):
             measurements=[],
             target_measurement=target_full_res,
             aperture_radius=4.0,
+            annulus_inner_radius=6.0,
+            annulus_outer_radius=9.0,
         )
 
         rgb = np.asarray(Image.open(BytesIO(jpeg_bytes)).convert("RGB"))
@@ -732,6 +734,62 @@ class TestAperturePhotometry(unittest.TestCase):
         self.assertGreater(len(marker), 0)
         self.assertAlmostEqual(float(np.mean(orange[:, 1])), float(np.mean(marker[:, 1])), delta=5.0)
         self.assertAlmostEqual(float(np.mean(orange[:, 0])), float(np.mean(marker[:, 0])), delta=5.0)
+
+    def test_overlay_draws_target_aperture_and_annulus_at_input_radii(self) -> None:
+        from datalab.datalab_session.utils.photometry_diagnostics import candidate_overlay_jpeg_bytes
+
+        height, width = 600, 600
+        header = {
+            "CTYPE1": "RA---TAN",
+            "CTYPE2": "DEC--TAN",
+            "CUNIT1": "deg",
+            "CUNIT2": "deg",
+            "CRVAL1": 100.0,
+            "CRVAL2": 20.0,
+            "CRPIX1": 0.0,
+            "CRPIX2": 0.0,
+            "CD1_1": TEST_DEG_PER_PIXEL,
+            "CD1_2": 0.0,
+            "CD2_1": 0.0,
+            "CD2_2": TEST_DEG_PER_PIXEL,
+        }
+        frame = SimpleNamespace(fits_path="target.fits", header=header, width=width, height=height)
+        image_data = np.full((height, width), 100.0, dtype=np.float32)
+        # 1 arcsec per pixel, so the arcsecond inputs below are also the full-resolution radii.
+        aperture_radius, annulus_inner_radius, annulus_outer_radius = 4.0, 6.0, 9.0
+
+        jpeg_bytes = candidate_overlay_jpeg_bytes(
+            frame=frame,
+            image=image_data,
+            stars=[],
+            measurements=[],
+            target_measurement=SimpleNamespace(x=300.0, y=300.0),
+            aperture_radius=aperture_radius,
+            annulus_inner_radius=annulus_inner_radius,
+            annulus_outer_radius=annulus_outer_radius,
+        )
+
+        rgb = np.asarray(Image.open(BytesIO(jpeg_bytes)).convert("RGB"))
+        out_height, out_width = rgb.shape[:2]
+        orange = np.argwhere(
+            (rgb[:, :, 0] > 180) &
+            (rgb[:, :, 1] > 80) &
+            (rgb[:, :, 1] < 170) &
+            (rgb[:, :, 2] < 90)
+        )
+        self.assertGreater(len(orange), 0)
+        # The single target sits at the crop center, so distance from the image center is the
+        # drawn radius. Only the crop's resample scale converts full-resolution radii to output
+        # pixels, so all three circles must land on the operation's own aperture geometry.
+        center_y, center_x = (out_height - 1) / 2.0, (out_width - 1) / 2.0
+        distances = np.hypot(orange[:, 0] - center_y, orange[:, 1] - center_x)
+        # Crop is a square of side 2 * pad + 1 around the target (pad = 2 * max(aperture_px, 14)).
+        scale = out_width / (2.0 * 2.0 * 14.0 + 1.0)
+        for input_radius in (aperture_radius, annulus_inner_radius, annulus_outer_radius):
+            expected = input_radius * scale
+            on_ring = np.abs(distances - expected) <= 6.0
+            self.assertGreater(int(np.count_nonzero(on_ring)), 100, f"no ring at {input_radius} arcsec")
+        self.assertLessEqual(float(np.max(distances)), annulus_outer_radius * scale + 6.0)
 
     def test_default_fits_dependencies_read_sci_header_and_cat_rows(self) -> None:
         frames, (target_ra, target_dec) = build_frame_set(frame_count=1)

--- a/datalab/datalab_session/utils/aperture_light_curve.py
+++ b/datalab/datalab_session/utils/aperture_light_curve.py
@@ -367,6 +367,8 @@ def generate_light_curve(
             measurements=comparison_measurements,
             target_measurement=target,
             aperture_radius=aperture_radius,
+            annulus_inner_radius=annulus_inner_radius,
+            annulus_outer_radius=annulus_outer_radius,
         )
 
         frame_results.append(
@@ -581,6 +583,8 @@ def _render_frame_overlay(
     measurements: Sequence[ComparisonMeasurement],
     target_measurement: TargetMeasurement,
     aperture_radius: float,
+    annulus_inner_radius: float,
+    annulus_outer_radius: float,
 ) -> bytes:
     """
         Reloads one frame's pixels and renders its diagnostic overlay, cropped at full resolution
@@ -597,6 +601,8 @@ def _render_frame_overlay(
         measurements=measurements,
         target_measurement=target_measurement,
         aperture_radius=aperture_radius,
+        annulus_inner_radius=annulus_inner_radius,
+        annulus_outer_radius=annulus_outer_radius,
     )
 
 

--- a/datalab/datalab_session/utils/photometry_diagnostics.py
+++ b/datalab/datalab_session/utils/photometry_diagnostics.py
@@ -25,13 +25,19 @@ def candidate_overlay_jpeg_bytes(
     measurements: Sequence[Any],
     target_measurement: Any,
     aperture_radius: float,
+    annulus_inner_radius: float,
+    annulus_outer_radius: float,
 ) -> bytes:
     """
         Renders the candidate-star overlay for one frame from its full-resolution pixels.
 
+        The target is drawn as the three circles the operation actually measured with — the
+        aperture, and the inner and outer bounds of the background annulus in a thinner line.
+        Candidates get a single circle at a legible fixed size, since their job is only to mark
+        which stars entered the ensemble.
+
         The image is cropped at full resolution to the region containing every drawn circle plus
-        a one-radius margin, then resampled so its long side is OVERLAY_MAX_DIMENSION, so tight
-        star fields keep native detail instead of inheriting a whole-frame downsample.
+        a margin, then resampled so its long side is OVERLAY_MAX_DIMENSION.
     """
     height, width = image.shape
     stars_by_id = {star.candidate_id: star for star in stars}
@@ -50,8 +56,15 @@ def candidate_overlay_jpeg_bytes(
     target_position = (target_x, target_y) if math.isfinite(target_x) and math.isfinite(target_y) else None
     positions = comparison_positions + ([target_position] if target_position else [])
 
-    radius_full = max(arcsec_to_pixels(frame.header, aperture_radius), 14.0)
-    x0, y0, x1, y1 = _crop_bounds(positions, pad=2.0 * radius_full, width=width, height=height)
+    # The target's circles are the operation's real apertures in this frame's pixels; the
+    # candidates' shared circle keeps a floor so it stays visible on wide-pixel-scale frames.
+    aperture_radius_full = arcsec_to_pixels(frame.header, aperture_radius)
+    annulus_inner_radius_full = arcsec_to_pixels(frame.header, annulus_inner_radius)
+    annulus_outer_radius_full = arcsec_to_pixels(frame.header, annulus_outer_radius)
+    radius_full = max(aperture_radius_full, 14.0)
+    # Pad past the largest circle drawn around any position so no annulus is cropped away.
+    pad_full = max(2.0 * radius_full, 1.2 * annulus_outer_radius_full)
+    x0, y0, x1, y1 = _crop_bounds(positions, pad=pad_full, width=width, height=height)
     crop = image[y0:y1, x0:x1]
     crop_height, crop_width = crop.shape
 
@@ -83,7 +96,17 @@ def candidate_overlay_jpeg_bytes(
     if target_position is not None:
         cx = (target_position[0] - x0 + 0.5) * scale_x - 0.5
         cy = ((crop_height - 1) - (target_position[1] - y0) + 0.5) * scale_y - 0.5
-        draw.ellipse((cx - radius, cy - radius, cx + radius, cy + radius), outline=TARGET_COLOR, width=line_width)
+        aperture = aperture_radius_full * scale
+        draw.ellipse((cx - aperture, cy - aperture, cx + aperture, cy + aperture), outline=TARGET_COLOR, width=line_width)
+        # The annulus circles are rendered at 0.5 or less line width than the aperture radius.
+        annulus_line_width = max(1, line_width // 2)
+        for annulus_radius_full in (annulus_inner_radius_full, annulus_outer_radius_full):
+            annulus = annulus_radius_full * scale
+            draw.ellipse(
+                (cx - annulus, cy - annulus, cx + annulus, cy + annulus),
+                outline=TARGET_COLOR,
+                width=annulus_line_width,
+            )
 
     buffer = BytesIO()
     overlay.save(buffer, format="JPEG", quality=90)

--- a/datalab/datalab_session/utils/photometry_diagnostics.py
+++ b/datalab/datalab_session/utils/photometry_diagnostics.py
@@ -58,13 +58,13 @@ def candidate_overlay_jpeg_bytes(
 
     # The target's circles are the operation's real apertures in this frame's pixels; the
     # candidates' shared circle keeps a floor so it stays visible on wide-pixel-scale frames.
-    aperture_radius_full = arcsec_to_pixels(frame.header, aperture_radius)
-    annulus_inner_radius_full = arcsec_to_pixels(frame.header, annulus_inner_radius)
-    annulus_outer_radius_full = arcsec_to_pixels(frame.header, annulus_outer_radius)
-    radius_full = max(aperture_radius_full, 14.0)
+    aperture_radius_pixel = arcsec_to_pixels(frame.header, aperture_radius)
+    annulus_inner_radius_pixel = arcsec_to_pixels(frame.header, annulus_inner_radius)
+    annulus_outer_radius_pixel = arcsec_to_pixels(frame.header, annulus_outer_radius)
+    radius_pixel = max(aperture_radius_pixel, 14.0)
     # Pad past the largest circle drawn around any position so no annulus is cropped away.
-    pad_full = max(2.0 * radius_full, 1.2 * annulus_outer_radius_full)
-    x0, y0, x1, y1 = _crop_bounds(positions, pad=pad_full, width=width, height=height)
+    pad = max(2.0 * radius_pixel, 1.2 * annulus_outer_radius_pixel)
+    x0, y0, x1, y1 = _crop_bounds(positions, pad=pad, width=width, height=height)
     crop = image[y0:y1, x0:x1]
     crop_height, crop_width = crop.shape
 
@@ -83,7 +83,7 @@ def candidate_overlay_jpeg_bytes(
     scale_x = out_width / crop_width
     scale_y = out_height / crop_height
     min_dimension = min(out_width, out_height)
-    radius = max(radius_full * scale, min_dimension * 0.035, 24.0)
+    radius = max(radius_pixel * scale, min_dimension * 0.035, 24.0)
     line_width = max(3, int(round(min_dimension * 0.004)))
 
     # The image is y-flipped for display, and pixel centers map through a resize as
@@ -96,11 +96,11 @@ def candidate_overlay_jpeg_bytes(
     if target_position is not None:
         cx = (target_position[0] - x0 + 0.5) * scale_x - 0.5
         cy = ((crop_height - 1) - (target_position[1] - y0) + 0.5) * scale_y - 0.5
-        aperture = aperture_radius_full * scale
+        aperture = aperture_radius_pixel * scale
         draw.ellipse((cx - aperture, cy - aperture, cx + aperture, cy + aperture), outline=TARGET_COLOR, width=line_width)
         # The annulus circles are rendered at 0.5 or less line width than the aperture radius.
         annulus_line_width = max(1, line_width // 2)
-        for annulus_radius_full in (annulus_inner_radius_full, annulus_outer_radius_full):
+        for annulus_radius_full in (annulus_inner_radius_pixel, annulus_outer_radius_pixel):
             annulus = annulus_radius_full * scale
             draw.ellipse(
                 (cx - annulus, cy - annulus, cx + annulus, cy + annulus),

--- a/datalab/datalab_session/utils/photometry_diagnostics.py
+++ b/datalab/datalab_session/utils/photometry_diagnostics.py
@@ -12,9 +12,9 @@ from datalab.datalab_session.utils.fits_metadata import arcsec_to_pixels, option
 from datalab.datalab_session.utils.flux_to_mag import flux_to_mag
 
 COMPARISON_STAR_COLOR = (0, 173, 239)
-TARGET_COLOR = (243, 131, 33)
+TARGET_COLOR = (255, 149, 0)
 # Diagnostic overlays are resampled so their long side is this many pixels.
-OVERLAY_MAX_DIMENSION = 1000
+OVERLAY_MAX_DIMENSION = 1500
 
 
 def candidate_overlay_jpeg_bytes(


### PR DESCRIPTION
Sizes the circle drawn around the target to the `aperture_radius` and also draws the inner/outer `annulus` with a half width line. 
Tweaks the color and size of the images for contrast and showing it full screen.