### PR TITLE
Refuse header-ephemeris photometry on sidereally tracked frames.

### DIFF
--- a/datalab/datalab_session/tests/test_moving_target_header_mode.py
+++ b/datalab/datalab_session/tests/test_moving_target_header_mode.py
@@ -222,6 +222,28 @@ class TestNonSiderealAperturePhotometry(unittest.TestCase):
                 locator=EphemerisHeaders(), comparison=SharedThenEvolving(),
             )
 
+    def test_sidereally_tracked_frames_are_refused(self) -> None:
+        # SRCTYPE says how the mount tracked. On a sidereal one CAT-RA/CAT-DEC is only the pointing,
+        # so a moving target drifts off it and the header cannot locate anything.
+        frames, _ = build_non_sidereal_frame_set(frame_count=3)
+        for frame in frames.values():
+            frame["header"]["SRCTYPE"] = "EXTRASOLAR"
+        with self.assertRaisesRegex(LightCurveError, "Moving Target Aperture Photometry"):
+            generate_light_curve(
+                self.write_frames(frames), aperture_radius=4.0, annulus_inner_radius=6.0,
+                annulus_outer_radius=9.0, locator=EphemerisHeaders(), comparison=SharedThenEvolving(),
+            )
+
+    def test_ephemeris_tracked_frames_are_accepted(self) -> None:
+        frames, _ = build_non_sidereal_frame_set(frame_count=6, ra_drift_arcsec_per_frame=8.0)
+        for frame in frames.values():
+            frame["header"]["SRCTYPE"] = "MINORPLANET"
+        result = generate_light_curve(
+            self.write_frames(frames), aperture_radius=4.0, annulus_inner_radius=6.0,
+            annulus_outer_radius=9.0, locator=EphemerisHeaders(), comparison=SharedThenEvolving(),
+        )
+        self.assertEqual(len(self._finite_rows(result)), 6)
+
     # ------------------------------------------------------------ target locating
 
     def test_header_target_is_measured_at_moving_position(self) -> None:

--- a/datalab/datalab_session/utils/target_location.py
+++ b/datalab/datalab_session/utils/target_location.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:  # avoid a runtime import cycle with aperture_light_curve
 
 log = logging.getLogger(__name__)
 
+SIDEREALLY_TRACKED_SOURCE_TYPE = "EXTRASOLAR"
+
 
 @dataclass(frozen=True)
 class TargetPositions:
@@ -59,10 +61,12 @@ class FixedPosition(TargetLocator):
 class EphemerisHeaders(TargetLocator):
     """
         A target whose mount tracked it, so each frame's CAT-RA/CAT-DEC record where it was. A frame
-        missing them is fatal: interpolating from neighbours would invent an ephemeris.
+        missing them is fatal: interpolating from neighbours would invent an ephemeris. Frames the
+        mount tracked sidereally are refused, since their CAT-RA/CAT-DEC records no such thing.
     """
 
     def locate(self, frames: Sequence[FrameContext]) -> TargetPositions:
+        _reject_sidereally_tracked(frames)
         positions: dict[str, tuple[float, float]] = {}
         for frame in frames:
             try:
@@ -83,6 +87,19 @@ class EphemerisHeaders(TargetLocator):
                 "Moving Target Aperture Photometry and mark it on two or more frames instead."
             )
         return TargetPositions(by_frame=positions, diagnostics=diagnostics)
+
+
+def _reject_sidereally_tracked(frames: Sequence[FrameContext]) -> None:
+    """Refuses frames whose mount tracked the stars, leaving CAT-RA/CAT-DEC as the pointing alone."""
+    if any(
+        str(frame.header.get("SRCTYPE", "")).strip().upper() == SIDEREALLY_TRACKED_SOURCE_TYPE
+        for frame in frames
+    ):
+        raise LightCurveError(
+            f"These frames were tracked sidereally (SRCTYPE={SIDEREALLY_TRACKED_SOURCE_TYPE}), so "
+            "CAT-RA/CAT-DEC is not the target's position. Use Moving Target Aperture Photometry and "
+            "mark the object on two or more frames."
+        )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## What

  `EphemerisHeaders` now refuses frames with fits header keyword `SRCTYPE = EXTRASOLAR`, before any
  pixels are read, and names the operation that can measure them instead.

  ## Why

  `SRCTYPE` records how the observation was scheduled, and so how the mount tracked.
  On a solar-system object the scheduler follows an ephemeris and `CAT-RA/CAT-DEC`
  carries the target's own position; on `EXTRASOLAR` those coordinates record where the telescope
  was pointed.

  ## Testing

  Two tests added: `EXTRASOLAR` frames are refused, `MINORPLANET` frames still produce
  a light curve. Full suite passes. Verified end to end on real data — the 3I/ATLAS rp
  frames are refused, Kleopatra still returns 13 rows.
